### PR TITLE
will not always use 'hive' as catalog

### DIFF
--- a/web/src/store/modules/treeview.js
+++ b/web/src/store/modules/treeview.js
@@ -78,7 +78,7 @@ const actions = {
 
     if (data.results && data.results.length) {
       commit('setCatalogs', {data: data.results.map(r => r[0])})
-      commit('setCatalog', {data: defaultCatalog || state.catalogs[0]})
+      commit('setCatalog', {data: state.catalogs[0] || defaultCatalog})
     } else {
       commit('setCatalogs', {data: []})
       if (data.error) {


### PR DESCRIPTION
yanagishima uses 'hive' as initial catalog for presto all the time even though there is no such one