### PR TITLE
Add a script to launch yanagishima in foreground process

### DIFF
--- a/src/package/bin/yanagishima-config.sh
+++ b/src/package/bin/yanagishima-config.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+bin=$(cd "$(dirname $0)"; pwd)
+YANAGISHIMA_HOME="${bin}/.."
+
+if [ -z "$YANAGISHIMA_CONF_DIR" ]; then
+  YANAGISHIMA_CONF_DIR=$YANAGISHIMA_HOME/conf
+fi
+
+for file in "$YANAGISHIMA_HOME"/lib/*.jar;
+do
+  CLASSPATH=$CLASSPATH:$file
+done
+
+if [ -z "$YANAGISHIMA_OPTS" ]; then
+  YANAGISHIMA_OPTS=-Xmx3G
+fi

--- a/src/package/bin/yanagishima-run.sh
+++ b/src/package/bin/yanagishima-run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+bin=$(cd "$(dirname $0)"; pwd)
+. "${bin}/yanagishima-config.sh"
+
+exec java $YANAGISHIMA_OPTS -cp $CLASSPATH yanagishima.server.YanagishimaServer -conf $YANAGISHIMA_CONF_DIR "$@"

--- a/src/package/bin/yanagishima-shutdown.sh
+++ b/src/package/bin/yanagishima-shutdown.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-yanagishima_dir=$(dirname $0)/..
+bin=$(cd "$(dirname $0)"; pwd)
+. "${bin}/yanagishima-config.sh"
 
-proc=`cat $yanagishima_dir/currentpid`
+proc=$(cat "$YANAGISHIMA_HOME"/currentpid)
 echo "killing YanagishimaServer"
 kill $proc
 
-cat /dev/null > $yanagishima_dir/currentpid
+cat /dev/null > "$YANAGISHIMA_HOME"/currentpid

--- a/src/package/bin/yanagishima-start.sh
+++ b/src/package/bin/yanagishima-start.sh
@@ -1,22 +1,8 @@
 #!/bin/bash
 
-yanagishima_dir=$(dirname $0)/..
+bin=$(cd "$(dirname $0)"; pwd)
+. "${bin}/yanagishima-config.sh"
 
-for file in $yanagishima_dir/lib/*.jar;
-do
-  CLASSPATH=$CLASSPATH:$file
-done
+java "$YANAGISHIMA_OPTS" -cp "$CLASSPATH" yanagishima.server.YanagishimaServer -conf "$YANAGISHIMA_CONF_DIR" "$@" &
 
-echo $yanagishima_dir;
-echo $CLASSPATH;
-
-executorport=`cat $yanagishima_dir/conf/yanagishima.properties | grep executor.port | cut -d = -f 2`
-serverpath=`pwd`
-
-if [ -z $YANAGISHIMA_OPTS ]; then
-  YANAGISHIMA_OPTS=-Xmx3G
-fi
-
-java $YANAGISHIMA_OPTS -cp $CLASSPATH yanagishima.server.YanagishimaServer -conf $yanagishima_dir/conf $@ &
-
-echo $! > $yanagishima_dir/currentpid
+echo $! > "$YANAGISHIMA_HOME"/currentpid


### PR DESCRIPTION
In container environment e.g docker, running process in foreground is useful to manage container lifecycle.
This PR adds yanagishima-run command to launch yanagishima in foreground process.
And extract common environment variables to yanagishima-config.sh