### PR TITLE
dockerize with web

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.github
+Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,9 @@ jobs:
           node-version: '12'
       - run: npm install
       - run: npm run build
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Docker Image
+        run: |
+          docker build ../

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM openjdk:11-jdk AS build
+
+ARG YANAGISHIMA_VERSION
+WORKDIR /root/
+
+# install node
+RUN bash -lc "curl -sL https://deb.nodesource.com/setup_11.x | bash - \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && deb https://dl.yarnpkg.com/debian/ stable main | tee /etc/apt/sources.list.d/yarn.list"
+RUN bash -lc "apt-get update -qq \
+    && apt-get install -qq --no-install-recommends nodejs yarn \
+    && rm -rf /var/lib/apt/lists/*"
+
+# web
+COPY web /root/yanagishima/web
+RUN bash -lc "cd /root/yanagishima/web \
+    && npm install \
+    && npm install -f node-sass \
+    && npm run build"
+# package
+COPY . /root/yanagishima
+RUN bash -lc "cd /root/yanagishima \
+    && ./gradlew :distZip"
+
+###########################################################################
+FROM openjdk:11-jre-stretch
+
+ARG YANAGISHIMA_VERSION
+WORKDIR /root/
+
+COPY --from=build /root/yanagishima/build/distributions/yanagishima-$YANAGISHIMA_VERSION.zip .
+
+RUN unzip yanagishima-$YANAGISHIMA_VERSION.zip \
+    && rm -f yanagishima-$YANAGISHIMA_VERSION.zip
+
+EXPOSE 8080
+
+CMD cd yanagishima-$YANAGISHIMA_VERSION \
+    && ./bin/yanagishima-start.sh


### PR DESCRIPTION
- dockerize yanagishima
  - use `openjdk:11-jdk`
  - install node11 to build yanagishima/web
    - i.e., https://github.com/nodesource/distributions/blob/master/deb/setup_11.x
  - deploy yanagishima with `openjdk:11-jre-stretch`