### PR TITLE
FIX-BUG: NPE when cluster is new.

### DIFF
--- a/src/main/java/yanagishima/util/YarnUtil.java
+++ b/src/main/java/yanagishima/util/YarnUtil.java
@@ -62,6 +62,9 @@ public final class YarnUtil {
     @VisibleForTesting
     public static List<Map> jsonToMaps(String json) throws IOException {
         Map map = OBJECT_MAPPER.readValue(json, Map.class);
+        if (map.get("apps") == null) {
+            return List.of();
+        }
         return (List) ((Map) map.get("apps")).get("app");
     }
 }


### PR DESCRIPTION
NPE when yarn have nothing to show. 
"/ws/v1/cluster/apps" will return an empty struct "`</apps>`".
"`</apps>`" causes NPE.