### PR TITLE
FEATURE:Customize hive jdbc driver

### DIFF
--- a/src/main/java/yanagishima/config/YanagishimaConfig.java
+++ b/src/main/java/yanagishima/config/YanagishimaConfig.java
@@ -400,4 +400,9 @@ public class YanagishimaConfig {
 	public boolean isUseOldPresto(String datasource) {
 		return Boolean.parseBoolean(properties.getProperty("use.old.presto." + datasource));
 	}
+
+    public String getHiveDriverClassName(String datawsource) {
+        String property = properties.getProperty("hive.jdbc.driver." + datawsource, "org.apache.hive.jdbc.HiveDriver");
+        return property;
+    }
 }

--- a/src/main/java/yanagishima/service/HiveServiceImpl.java
+++ b/src/main/java/yanagishima/service/HiveServiceImpl.java
@@ -121,7 +121,7 @@ public class HiveServiceImpl implements HiveService {
         checkRequiredCondition(userName, query, datasource, queryId, engine);
 
         try {
-            Class.forName("org.apache.hive.jdbc.HiveDriver");
+            Class.forName(config.getHiveDriverClassName(datasource));
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Cloudera's hive-jdbc driver class name is `com.cloudera.hive.jdbc41.HS2Driver`. 
In project, hard code `org.apache.hive.jdbc.HiveDriver` is only suit for apache hive-jdbc.
Add `hive.jdbc.driver. config.${datasource}` property for customize hive-jdbc driver class name.

BTW, I didn't find the document where is, and my poor english skill. May contributer make documents up?

Referer:https://www.cloudera.com/downloads/connectors/hive/jdbc/2-6-2.html.
