### PR TITLE
Introduce Spring and apply to health check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,9 @@ dependencies {
     compile 'org.jsoup:jsoup:1.11.3'
     compile 'mysql:mysql-connector-java:5.1.47'
     compile 'com.zaxxer:HikariCP:3.4.5'
+    compile 'org.springframework:spring-core:5.2.11.RELEASE'
+    compile 'org.springframework:spring-webmvc:5.2.11.RELEASE'
+    compile 'org.springframework:spring-context-support:5.2.11.RELEASE'
 
     errorprone 'com.google.errorprone:error_prone_core:2.3.4'
 

--- a/src/main/java/yanagishima/client/JdbcClient.java
+++ b/src/main/java/yanagishima/client/JdbcClient.java
@@ -1,0 +1,22 @@
+package yanagishima.client;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.google.inject.Injector;
+
+import yanagishima.repository.TinyOrm;
+
+@Component
+public class JdbcClient {
+  private final TinyOrm tinyOrm;
+
+  @Autowired
+  public JdbcClient(Injector injector) {
+    this.tinyOrm = injector.getInstance(TinyOrm.class);
+  }
+
+  public void executeQuery(String sql) {
+    tinyOrm.executeQuery(sql);
+  }
+}

--- a/src/main/java/yanagishima/config/AppConfig.java
+++ b/src/main/java/yanagishima/config/AppConfig.java
@@ -1,0 +1,8 @@
+package yanagishima.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = "yanagishima")
+public class AppConfig { }

--- a/src/main/java/yanagishima/config/GuiceConfig.java
+++ b/src/main/java/yanagishima/config/GuiceConfig.java
@@ -1,0 +1,16 @@
+package yanagishima.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.inject.Injector;
+
+import yanagishima.server.YanagishimaServer;
+
+@Configuration
+public class GuiceConfig {
+  @Bean
+  public Injector injector() {
+    return YanagishimaServer.injector;
+  }
+}

--- a/src/main/java/yanagishima/config/WebMvcConfig.java
+++ b/src/main/java/yanagishima/config/WebMvcConfig.java
@@ -4,12 +4,12 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebMvc
 @ComponentScan(basePackages = { "yanagishima.controller" })
-public class WebMvcConfig extends WebMvcConfigurerAdapter {
+public class WebMvcConfig implements WebMvcConfigurer {
   @Override
   public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {
     configurer.enable("default");

--- a/src/main/java/yanagishima/config/WebMvcConfig.java
+++ b/src/main/java/yanagishima/config/WebMvcConfig.java
@@ -1,0 +1,17 @@
+package yanagishima.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@Configuration
+@EnableWebMvc
+@ComponentScan(basePackages = { "yanagishima.controller" })
+public class WebMvcConfig extends WebMvcConfigurerAdapter {
+  @Override
+  public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {
+    configurer.enable("default");
+  }
+}

--- a/src/main/java/yanagishima/module/PrestoServletModule.java
+++ b/src/main/java/yanagishima/module/PrestoServletModule.java
@@ -34,7 +34,6 @@ public class PrestoServletModule extends ServletModule {
 		bind(LabelServlet.class);
 		bind(StarredSchemaServlet.class);
 		bind(CheckPrestoQueryServlet.class);
-		bind(HealthCheckServlet.class);
 
 		serve("/presto").with(PrestoServlet.class);
 		serve("/prestoAsync").with(PrestoAsyncServlet.class);
@@ -64,6 +63,5 @@ public class PrestoServletModule extends ServletModule {
 		serve("/label").with(LabelServlet.class);
 		serve("/starredSchema").with(StarredSchemaServlet.class);
 		serve("/checkPrestoQuery").with(CheckPrestoQueryServlet.class);
-		serve("/healthCheck").with(HealthCheckServlet.class);
 	}
 }

--- a/src/main/java/yanagishima/servlet/HealthCheckServlet.java
+++ b/src/main/java/yanagishima/servlet/HealthCheckServlet.java
@@ -1,28 +1,18 @@
 package yanagishima.servlet;
 
-import yanagishima.repository.TinyOrm;
+import lombok.RequiredArgsConstructor;
+import yanagishima.client.JdbcClient;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Singleton
-public class HealthCheckServlet extends HttpServlet {
-    private static final long serialVersionUID = 1L;
+@RestController
+@RequiredArgsConstructor
+public class HealthCheckServlet {
+    private final JdbcClient jdbcClient;
 
-    private final TinyOrm db;
-
-    @Inject
-    public HealthCheckServlet(TinyOrm db) {
-        this.db = db;
-    }
-
-    @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        db.executeQuery("select 1");
+    @GetMapping("healthCheck")
+    public void get() {
+        jdbcClient.executeQuery("select 1");
     }
 }


### PR DESCRIPTION
I didn't rename `HealthCheckServlet` intentionally to keep git history. We can rename later. 

```bash
curl -v http://localhost:8080/healthCheck
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /healthCheck HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Tue, 08 Dec 2020 01:00:23 GMT
< Access-Control-Allow-Headers: X-yanagishima-datasources, some.auth.header
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET, POST, OPTIONS, DELETE
< Content-Length: 0
< Server: Jetty(9.4.25.v20191220)
<
* Connection #0 to host localhost left intact
* Closing connection 0
```

UI appears correctly.
<img width="1303" alt="Screen Shot 2020-12-08 at 10 30 25" src="https://user-images.githubusercontent.com/6237050/101426520-76473380-3940-11eb-98b8-136c815d04d3.png">


Related to #184