### PR TITLE
Migrate convert Presto servlet to spring

### DIFF
--- a/src/main/java/yanagishima/model/dto/PrestoQueryDto.java
+++ b/src/main/java/yanagishima/model/dto/PrestoQueryDto.java
@@ -1,0 +1,10 @@
+package yanagishima.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PrestoQueryDto {
+  private final String prestoQuery;
+}

--- a/src/main/java/yanagishima/module/PrestoServletModule.java
+++ b/src/main/java/yanagishima/module/PrestoServletModule.java
@@ -28,7 +28,6 @@ public class PrestoServletModule extends ServletModule {
 		bind(BookmarkUserServlet.class);
 		bind(PrestoPartitionServlet.class);
 		bind(CommentServlet.class);
-		bind(ConvertPrestoServlet.class);
 		bind(LabelServlet.class);
 		bind(StarredSchemaServlet.class);
 		bind(CheckPrestoQueryServlet.class);
@@ -55,7 +54,6 @@ public class PrestoServletModule extends ServletModule {
 		serve("/bookmarkUser").with(BookmarkUserServlet.class);
 		serve("/prestoPartition").with(PrestoPartitionServlet.class);
 		serve("/comment").with(CommentServlet.class);
-		serve("/convertPresto").with(ConvertPrestoServlet.class);
 		serve("/label").with(LabelServlet.class);
 		serve("/starredSchema").with(StarredSchemaServlet.class);
 		serve("/checkPrestoQuery").with(CheckPrestoQueryServlet.class);

--- a/src/main/java/yanagishima/servlet/ConvertPrestoServlet.java
+++ b/src/main/java/yanagishima/servlet/ConvertPrestoServlet.java
@@ -1,35 +1,20 @@
 package yanagishima.servlet;
 
-import static yanagishima.util.JsonUtil.writeJSON;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import yanagishima.model.dto.PrestoQueryDto;
 
-import javax.inject.Singleton;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+@RestController
+public class ConvertPrestoServlet {
+  @PostMapping("convertPresto")
+  public PrestoQueryDto post(@RequestParam String query) {
+    return new PrestoQueryDto(toPrestoQuery(query));
+  }
 
-import yanagishima.model.HttpRequestContext;
-
-@Singleton
-public class ConvertPrestoServlet extends HttpServlet {
-	private static final long serialVersionUID = 1L;
-
-	@Override
-	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		HttpRequestContext context = new HttpRequestContext(request);
-		Map<String, Object> responseBody = new HashMap<>();
-		if (context.getQuery() != null) {
-			responseBody.put("prestoQuery", toPrestoQuery(context.getQuery()));
-		}
-		writeJSON(response, responseBody);
-	}
-
-	private static String toPrestoQuery(String hiveQuery) {
-		return hiveQuery.replace("get_json_object", "json_extract_scalar")
-						.replace("lateral view explode", "cross join unnest");
-	}
+  private static String toPrestoQuery(String hiveQuery) {
+    return hiveQuery.replace("get_json_object", "json_extract_scalar")
+                    .replace("lateral view explode", "cross join unnest");
+  }
 }


### PR DESCRIPTION
Related to #184

Existing servlet doesn't throw an exception when `query` param doesn't exist. Changed to required param because UI doesn't show convert button in such case.  