### PR TITLE
Migrate convert Hive servlet to spring

### DIFF
--- a/src/main/java/yanagishima/model/dto/HiveQueryDto.java
+++ b/src/main/java/yanagishima/model/dto/HiveQueryDto.java
@@ -1,0 +1,10 @@
+package yanagishima.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HiveQueryDto {
+  private final String hiveQuery;
+}

--- a/src/main/java/yanagishima/module/HiveServletModule.java
+++ b/src/main/java/yanagishima/module/HiveServletModule.java
@@ -14,7 +14,6 @@ public class HiveServletModule extends ServletModule {
 		bind(HiveQueryStatusServlet.class);
 		bind(HiveQueryDetailServlet.class);
 		bind(HivePartitionServlet.class);
-		bind(ConvertHiveServlet.class);
 
 		serve("/hive").with(HiveServlet.class);
 		serve("/spark").with(HiveServlet.class);
@@ -29,6 +28,5 @@ public class HiveServletModule extends ServletModule {
 		serve("/sparkQueryDetail").with(HiveQueryDetailServlet.class);
 		serve("/hivePartition").with(HivePartitionServlet.class);
 		serve("/sparkPartition").with(HivePartitionServlet.class);
-		serve("/convertHive").with(ConvertHiveServlet.class);
 	}
 }

--- a/src/main/java/yanagishima/servlet/ConvertHiveServlet.java
+++ b/src/main/java/yanagishima/servlet/ConvertHiveServlet.java
@@ -1,35 +1,20 @@
 package yanagishima.servlet;
 
-import static yanagishima.util.JsonUtil.writeJSON;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import yanagishima.model.dto.HiveQueryDto;
 
-import javax.inject.Singleton;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+@RestController
+public class ConvertHiveServlet {
+  @PostMapping("convertHive")
+  public HiveQueryDto post(@RequestParam String query) {
+    return new HiveQueryDto(toHiveQuery(query));
+  }
 
-import yanagishima.model.HttpRequestContext;
-
-@Singleton
-public class ConvertHiveServlet extends HttpServlet {
-	private static final long serialVersionUID = 1L;
-
-	@Override
-	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		HttpRequestContext context = new HttpRequestContext(request);
-		Map<String, Object> responseBody = new HashMap<>();
-		if (context.getQuery() != null) {
-			responseBody.put("hiveQuery", toHiveQuery(context.getQuery()));
-		}
-		writeJSON(response, responseBody);
-	}
-
-	private static String toHiveQuery(String prestoQuery) {
-		return prestoQuery.replace("json_extract_scalar", "get_json_object")
-						  .replace("cross join unnest", "lateral view explode");
-	}
+  private static String toHiveQuery(String prestoQuery) {
+    return prestoQuery.replace("json_extract_scalar", "get_json_object")
+                      .replace("cross join unnest", "lateral view explode");
+  }
 }


### PR DESCRIPTION
Related to #184

Existing servlet doesn't throw an exception when `query` param doesn't exist. Changed to required param because UI doesn't show convert button in such case. 