### PR TITLE
Migrate history servlets to spring

### DIFF
--- a/src/main/java/yanagishima/module/PrestoServletModule.java
+++ b/src/main/java/yanagishima/module/PrestoServletModule.java
@@ -11,9 +11,7 @@ public class PrestoServletModule extends ServletModule {
 		bind(QueryServlet.class);
 		bind(PrestoKillServlet.class);
 		bind(FormatSqlServlet.class);
-		bind(HistoryServlet.class);
 		bind(HistoryStatusServlet.class);
-		bind(ShareHistoryServlet.class);
 		bind(CsvDownloadServlet.class);
 		bind(ShareCsvDownloadServlet.class);
 		bind(QueryHistoryServlet.class);
@@ -31,9 +29,7 @@ public class PrestoServletModule extends ServletModule {
 		serve("/query").with(QueryServlet.class);
 		serve("/kill").with(PrestoKillServlet.class);
 		serve("/format").with(FormatSqlServlet.class);
-		serve("/history").with(HistoryServlet.class);
 		serve("/historyStatus").with(HistoryStatusServlet.class);
-		serve("/share/shareHistory").with(ShareHistoryServlet.class);
 		serve("/csvdownload").with(CsvDownloadServlet.class);
 		serve("/share/csvdownload").with(ShareCsvDownloadServlet.class);
 		serve("/queryHistory").with(QueryHistoryServlet.class);

--- a/src/main/java/yanagishima/servlet/ShareHistoryServlet.java
+++ b/src/main/java/yanagishima/servlet/ShareHistoryServlet.java
@@ -1,45 +1,35 @@
 package yanagishima.servlet;
 
-import lombok.extern.slf4j.Slf4j;
-import yanagishima.config.YanagishimaConfig;
-import yanagishima.repository.TinyOrm;
-import yanagishima.model.db.Comment;
-import yanagishima.model.db.Query;
-import yanagishima.model.db.SessionProperty;
+import static yanagishima.util.HistoryUtil.createHistoryResult;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static yanagishima.util.HistoryUtil.createHistoryResult;
-import static yanagishima.util.HttpRequestUtil.getRequiredParameter;
-import static yanagishima.util.JsonUtil.writeJSON;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import yanagishima.config.YanagishimaConfig;
+import yanagishima.model.db.Comment;
+import yanagishima.model.db.Query;
+import yanagishima.model.db.SessionProperty;
+import yanagishima.repository.TinyOrm;
 
 @Slf4j
-@Singleton
-public class ShareHistoryServlet extends HttpServlet {
-    private static final long serialVersionUID = 1L;
-
+@RestController
+@RequiredArgsConstructor
+public class ShareHistoryServlet {
     private final YanagishimaConfig config;
     private final TinyOrm db;
 
-    @Inject
-    public ShareHistoryServlet(YanagishimaConfig config, TinyOrm db) {
-        this.config = config;
-        this.db = db;
-    }
-
-    @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+    @GetMapping("share/shareHistory")
+    public Map<String, Object> get(@RequestParam(name = "publish_id") String publishId) {
         Map<String, Object> body = new HashMap<>();
         try {
-            String publishId = getRequiredParameter(request, "publish_id");
             db.singlePublish("publish_id = ?", publishId).ifPresent(publish -> {
                 String datasource = publish.getDatasource();
                 body.put("datasource", datasource);
@@ -56,6 +46,6 @@ public class ShareHistoryServlet extends HttpServlet {
             log.error(e.getMessage(), e);
             body.put("error", e.getMessage());
         }
-        writeJSON(response, body);
+        return body;
     }
 }


### PR DESCRIPTION
Used `Map` type because we need to refactor `HistoryUtil.createHistoryResult` method. 

```bash
$ curl -s 'http://localhost:8080/history?datasource=docker-presto&engine=presto&queryid=20201217_112735_00014_9ej6w' |  jq
{
  "headers": [
    "_col0"
  ],
  "session_property": {},
  "rawDataSize": "8B",
  "engine": "presto",
  "editLabel": false,
  "finishedTime": "2020-12-17T20:27:35.934613+09:00[Asia/Tokyo]",
  "queryString": "select 1",
  "lineNumber": 2,
  "user": null,
  "results": [
    [
      "1"
    ]
  ],
  "elapsedTimeMillis": 934
}

$ curl -s 'http://localhost:8080/share/shareHistory?publish_id=d4a1bcccbda69efbd78f79659292f2f6' |  jq
{
  "headers": [
    "_col0"
  ],
  "session_property": {},
  "rawDataSize": "8B",
  "queryString": "select 1",
  "elapsedTimeMillis": 934,
  "queryid": "20201217_112735_00014_9ej6w",
  "engine": "presto",
  "datasource": "docker-presto",
  "finishedTime": "2020-12-17T20:27:35.934613+09:00[Asia/Tokyo]",
  "comment": null,
  "lineNumber": 2,
  "user": null,
  "results": [
    [
      "1"
    ]
  ]
}
```

Related to #184