### PR TITLE
Migrate query history servlet to spring

### DIFF
--- a/src/main/java/yanagishima/module/PrestoServletModule.java
+++ b/src/main/java/yanagishima/module/PrestoServletModule.java
@@ -6,10 +6,8 @@ import yanagishima.servlet.*;
 public class PrestoServletModule extends ServletModule {
 	@Override
 	protected void configureServlets() {
-		bind(QueryHistoryServlet.class);
 		bind(LabelServlet.class);
 
-		serve("/queryHistory").with(QueryHistoryServlet.class);
 		serve("/label").with(LabelServlet.class);
 	}
 }

--- a/src/main/java/yanagishima/servlet/QueryHistoryServlet.java
+++ b/src/main/java/yanagishima/servlet/QueryHistoryServlet.java
@@ -1,19 +1,15 @@
 package yanagishima.servlet;
 
 import io.airlift.units.DataSize;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import yanagishima.config.YanagishimaConfig;
 import yanagishima.repository.TinyOrm;
 import yanagishima.model.db.Query;
 
 import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -22,40 +18,31 @@ import static java.lang.String.join;
 import static java.util.Collections.nCopies;
 import static yanagishima.util.AccessControlUtil.sendForbiddenError;
 import static yanagishima.util.AccessControlUtil.validateDatasource;
-import static yanagishima.util.HttpRequestUtil.getRequiredParameter;
-import static yanagishima.util.JsonUtil.writeJSON;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@Singleton
-public class QueryHistoryServlet extends HttpServlet {
-    private static final long serialVersionUID = 1L;
-
+@RestController
+@RequiredArgsConstructor
+public class QueryHistoryServlet {
     private final YanagishimaConfig config;
     private final TinyOrm db;
 
-    @Inject
-    public QueryHistoryServlet(YanagishimaConfig config, TinyOrm db) {
-        this.config = config;
-        this.db = db;
-    }
-
-    @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        doGet(request, response);
-    }
-
-    @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response) {
+    @RequestMapping(value = "/queryHistory", method = { RequestMethod.GET, RequestMethod.POST })
+    public Map<String, Object> get(@RequestParam String datasource,
+                                   @RequestParam(required = false) String queryids,
+                                   @RequestParam(required = false) String label,
+                                   HttpServletRequest request, HttpServletResponse response) {
         Map<String, Object> responseBody = new HashMap<>();
         try {
-            String datasource = getRequiredParameter(request, "datasource");
             if (config.isCheckDatasource() && !validateDatasource(request, datasource)) {
                 sendForbiddenError(response);
-                return;
+                return responseBody;
             }
-            String[] queryIds = request.getParameter("queryids").split(",");
-            String label = request.getParameter("label");
-
+            String[] queryIds = queryids.split(","); // TODO: Fix NPE
             responseBody.put("headers", Arrays.asList("Id", "Query", "Time", "rawDataSize", "engine", "finishedTime", "linenumber", "labelName", "status"));
             responseBody.put("results", getHistories(label, datasource, queryIds));
 
@@ -63,7 +50,7 @@ public class QueryHistoryServlet extends HttpServlet {
             log.error(e.getMessage(), e);
             responseBody.put("error", e.getMessage());
         }
-        writeJSON(response, responseBody);
+        return responseBody;
     }
 
     private List<List<Object>> getHistories(String label, String datasource, String[] queryIds) {


### PR DESCRIPTION
```bash
# POST
$ curl -sS -X POST 'http://localhost:8080/queryHistory?datasource=docker-presto&queryids=20201224_023009_00033_f9fa9,20201223_045753_00012_gwyyc' | jq
{
  "headers": [
    "Id",
    "Query",
    "Time",
    "rawDataSize",
    "engine",
    "finishedTime",
    "linenumber",
    "labelName",
    "status"
  ],
  "results": [
    [
      "20201223_045753_00012_gwyyc",
      "select 1",
      313,
      "8B",
      "presto",
      "2020-12-23T13:57:53.313393+09:00[Asia/Tokyo]",
      2,
      null,
      "SUCCEED"
    ],
    [
      "20201224_023009_00033_f9fa9",
      "SELECT * FROM tpch.sf1.\"part\" LIMIT 100",
      -6004,
      "11.68kB",
      "presto",
      "2020-12-24T11:30:02.995682+09:00[Asia/Tokyo]",
      101,
      null,
      "SUCCEED"
    ]
  ]
}

# GET
$ curl -sS -X GET 'http://localhost:8080/queryHistory?datasource=docker-presto&queryids=20201224_023009_00033_f9fa9,20201223_045753_00012_gwyyc' | jq
{
  "headers": [
    "Id",
    "Query",
    "Time",
    "rawDataSize",
    "engine",
    "finishedTime",
    "linenumber",
    "labelName",
    "status"
  ],
  "results": [
    [
      "20201223_045753_00012_gwyyc",
      "select 1",
      313,
      "8B",
      "presto",
      "2020-12-23T13:57:53.313393+09:00[Asia/Tokyo]",
      2,
      null,
      "SUCCEED"
    ],
    [
      "20201224_023009_00033_f9fa9",
      "SELECT * FROM tpch.sf1.\"part\" LIMIT 100",
      -6004,
      "11.68kB",
      "presto",
      "2020-12-24T11:30:02.995682+09:00[Asia/Tokyo]",
      101,
      null,
      "SUCCEED"
    ]
  ]
}
```