### PR TITLE
Add stacktrace when hive query error occurs

### DIFF
--- a/src/main/java/yanagishima/service/HiveService.java
+++ b/src/main/java/yanagishima/service/HiveService.java
@@ -85,8 +85,6 @@ public class HiveService {
         int limit = config.getSelectLimit();
         getHiveQueryResult(queryId, engine, datasource, query, true, limit, userName, hiveUser, hivePassword,
                            true);
-      } catch (HiveQueryErrorException e) {
-        log.warn(e.getCause().getMessage());
       } catch (Throwable e) {
         log.error(e.getMessage(), e);
       }


### PR DESCRIPTION
There is no stacktrace when hive query error occurs now, we need to improve
```
2021/03/01 17:53:25.698 +0900 WARN [HiveService] [Yanagishima] Error retrieving next row
```

I think ```catch (HiveQueryErrorException e) ``` is not necessary