### PR TITLE
Use trinodb/presto image in ghcr.io

### DIFF
--- a/docker/presto/docker-compose.yml
+++ b/docker/presto/docker-compose.yml
@@ -2,6 +2,6 @@ version: '2'
 services:
   presto:
     hostname: presto
-    image: 'prestosql/presto:347'
+    image: 'ghcr.io/trinodb/presto:347'
     ports:
       - '18080:8080'


### PR DESCRIPTION
https://hub.docker.com/r/prestosql/presto was removed. 