### PR TITLE
add publish authorization logic

### DIFF
--- a/src/main/java/yanagishima/client/fluentd/FluencyClient.java
+++ b/src/main/java/yanagishima/client/fluentd/FluencyClient.java
@@ -21,7 +21,8 @@ public class FluencyClient {
 
   @PostConstruct
   public void postConstruct() {
-    if (config.getFluentdExecutedTag().isPresent() || config.getFluentdFaliedTag().isPresent()) {
+    if (config.getFluentdExecutedTag().isPresent() || config.getFluentdFaliedTag().isPresent()
+            || config.getFluentdPublishTag().isPresent()) {
       try {
         this.fluency = Fluency.defaultFluency(config.getFluentdHost(), config.getFluentdPort());
       } catch (IOException e) {
@@ -51,6 +52,18 @@ public class FluencyClient {
 
     try {
       fluency.emit(config.getFluentdFaliedTag().get(), event);
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+    }
+  }
+
+  public void emitPublish(Map<String, Object> event) {
+    if (config.getFluentdPublishTag().isEmpty()) {
+      return;
+    }
+
+    try {
+      fluency.emit(config.getFluentdPublishTag().get(), event);
     } catch (IOException e) {
       log.error(e.getMessage(), e);
     }

--- a/src/main/java/yanagishima/config/YanagishimaConfig.java
+++ b/src/main/java/yanagishima/config/YanagishimaConfig.java
@@ -158,6 +158,10 @@ public class YanagishimaConfig {
     return Optional.ofNullable(environment.getProperty("fluentd.failed.tag"));
   }
 
+  public Optional<String> getFluentdPublishTag() {
+    return Optional.ofNullable(environment.getProperty("fluentd.publish.tag"));
+  }
+
   public String getFluentdHost() {
     return firstNonNull(environment.getProperty("fluentd.host"), "localhost");
   }

--- a/src/main/java/yanagishima/controller/PublishController.java
+++ b/src/main/java/yanagishima/controller/PublishController.java
@@ -54,10 +54,11 @@ public class PublishController {
 
   @DatasourceAuth
   @GetMapping("publishList")
-  public PublishListDto list(@RequestParam String datasource, @RequestParam String engine, User user) {
+  public PublishListDto list(@RequestParam String datasource, @RequestParam String engine, User user,
+                             @RequestParam(defaultValue = "100") int limit) {
     PublishListDto publishListDto = new PublishListDto();
     try {
-      publishListDto.setPublishList(publishService.getAll(datasource, engine, user));
+      publishListDto.setPublishList(publishService.getAll(datasource, engine, user, limit));
     } catch (Throwable e) {
       log.error(e.getMessage(), e);
       publishListDto.setError(e.getMessage());

--- a/src/main/java/yanagishima/controller/PublishController.java
+++ b/src/main/java/yanagishima/controller/PublishController.java
@@ -3,6 +3,7 @@ package yanagishima.controller;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +15,7 @@ import yanagishima.annotation.DatasourceAuth;
 import yanagishima.config.YanagishimaConfig;
 import yanagishima.model.User;
 import yanagishima.model.dto.PublishDto;
+import yanagishima.model.dto.PublishListDto;
 import yanagishima.service.PublishService;
 import yanagishima.service.QueryService;
 
@@ -48,5 +50,18 @@ public class PublishController {
       publishDto.setError(e.getMessage());
     }
     return publishDto;
+  }
+
+  @DatasourceAuth
+  @GetMapping("publishList")
+  public PublishListDto list(@RequestParam String datasource, @RequestParam String engine, User user) {
+    PublishListDto publishListDto = new PublishListDto();
+    try {
+      publishListDto.setPublishList(publishService.getAll(datasource, engine, user));
+    } catch (Throwable e) {
+      log.error(e.getMessage(), e);
+      publishListDto.setError(e.getMessage());
+    }
+    return publishListDto;
   }
 }

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -103,7 +103,7 @@ public class ShareController {
         String requestUser = user.getId();
         String viewers = publish.getViewers();
         if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
-          body.put("accessDeniedFlag", true);
+          AccessControlUtil.sendForbiddenError(response);
           return;
         }
         if (publishUser != null && publishUser.equals(requestUser)) {

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -24,6 +24,7 @@ import yanagishima.client.fluentd.FluencyClient;
 import yanagishima.config.YanagishimaConfig;
 import yanagishima.model.User;
 import yanagishima.model.db.Comment;
+import yanagishima.model.db.Publish;
 import yanagishima.model.db.Query;
 import yanagishima.model.db.SessionProperty;
 import yanagishima.service.CommentService;
@@ -141,8 +142,7 @@ public class ShareController {
         if (publishUser != null && publishUser.equals(requestUser)) {
           publishService.update(publish, viewers);
           body.put("viewers", viewers);
-          emitPublishEvent(publish.getPublishId(), publish.getDatasource(), publish.getEngine(),
-                  publish.getQueryId(), publish.getUser(), viewers);
+          emitPublishEvent(publish, viewers, "share/updateViewers");
         } else {
           AccessControlUtil.sendForbiddenError(response);
           return;
@@ -155,15 +155,15 @@ public class ShareController {
     return body;
   }
 
-  private void emitPublishEvent(String publishId, String datasource, String engine, String queryId, String user,
-                                String viewers) {
+  private void emitPublishEvent(Publish publish, String viewers, String path) {
     Map<String, Object> event = new HashMap<>();
-    event.put("publish_id", publishId);
-    event.put("datasource", datasource);
-    event.put("engine", engine);
-    event.put("query_id", queryId);
-    event.put("user", user);
+    event.put("publish_id", publish.getPublishId());
+    event.put("datasource", publish.getDatasource());
+    event.put("engine", publish.getEngine());
+    event.put("query_id", publish.getQueryId());
+    event.put("user", publish.getUser());
     event.put("viewers", viewers);
+    event.put("path", path);
     fluencyClient.emitPublish(event);
   }
 }

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -140,9 +140,10 @@ public class ShareController {
         String publishUser = publish.getUser();
         String requestUser = user.getId();
         if (publishUser != null && publishUser.equals(requestUser)) {
-          publishService.update(publish, viewers);
-          body.put("viewers", viewers);
-          emitPublishEvent(publish, viewers, "share/updateViewers");
+          String lowerViewers = viewers.toLowerCase();
+          publishService.update(publish, lowerViewers);
+          body.put("viewers", lowerViewers);
+          emitPublishEvent(publish, lowerViewers, "share/updateViewers");
         } else {
           AccessControlUtil.sendForbiddenError(response);
           return;

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -12,13 +12,16 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import yanagishima.client.fluentd.FluencyClient;
 import yanagishima.config.YanagishimaConfig;
+import yanagishima.model.User;
 import yanagishima.model.db.Comment;
 import yanagishima.model.db.Query;
 import yanagishima.model.db.SessionProperty;
@@ -37,6 +40,7 @@ public class ShareController {
   private final SessionPropertyService sessionPropertyService;
   private final CommentService commentService;
   private final YanagishimaConfig config;
+  private final FluencyClient fluencyClient;
 
   @GetMapping("share/csvdownload")
   public void get(@RequestParam(name = "publish_id", required = false) String publishId,
@@ -71,10 +75,15 @@ public class ShareController {
   }
 
   @GetMapping("share/shareHistory")
-  public Map<String, Object> get(@RequestParam(name = "publish_id") String publishId) {
+  public Map<String, Object> get(@RequestParam(name = "publish_id") String publishId, User user) {
     Map<String, Object> body = new HashMap<>();
     try {
       publishService.get(publishId).ifPresent(publish -> {
+        String publishUser = publish.getUser();
+        String requestUser = user.getId();
+        if (publishUser != null && publishUser.equals(requestUser)) {
+          body.put("viewers", publish.getViewers());
+        }
         String datasource = publish.getDatasource();
         body.put("datasource", datasource);
         String queryId = publish.getQueryId();
@@ -92,5 +101,39 @@ public class ShareController {
       body.put("error", e.getMessage());
     }
     return body;
+  }
+
+  @PostMapping("share/updateViewers")
+  public Map<String, Object> updateViewers(@RequestParam(name = "publish_id") String publishId, User user,
+                                           String viewers) {
+    Map<String, Object> body = new HashMap<>();
+    try {
+      publishService.get(publishId).ifPresent(publish -> {
+        String publishUser = publish.getUser();
+        String requestUser = user.getId();
+        if (publishUser != null && publishUser.equals(requestUser)) {
+          publishService.update(publish, viewers);
+          body.put("viewers", viewers);
+          emitPublishEvent(publish.getPublishId(), publish.getDatasource(), publish.getEngine(),
+                  publish.getQueryId(), publish.getUser(), viewers);
+        }
+      });
+    } catch (Throwable e) {
+      log.error(e.getMessage(), e);
+      body.put("error", e.getMessage());
+    }
+    return body;
+  }
+
+  private void emitPublishEvent(String publishId, String datasource, String engine, String queryId, String user,
+                                String viewers) {
+    Map<String, Object> event = new HashMap<>();
+    event.put("publish_id", publishId);
+    event.put("datasource", datasource);
+    event.put("engine", engine);
+    event.put("query_id", queryId);
+    event.put("user", user);
+    event.put("viewers", viewers);
+    fluencyClient.emitPublish(event);
   }
 }

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -128,8 +128,10 @@ public class ShareController {
   }
 
   @PostMapping("share/updateViewers")
-  public Map<String, Object> updateViewers(@RequestParam(name = "publish_id") String publishId, User user,
-                                           String viewers, HttpServletResponse response) {
+  public Map<String, Object> updateViewers(@RequestParam(name = "publish_id") String publishId,
+                                           @RequestParam String viewers,
+                                           User user,
+                                           HttpServletResponse response) {
     Map<String, Object> body = new HashMap<>();
     try {
       publishService.get(publishId).ifPresent(publish -> {

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -105,6 +105,7 @@ public class ShareController {
           return;
         }
         if (publishUser != null && publishUser.equals(requestUser)) {
+          body.put("publisherFlag", true);
           body.put("viewers", viewers);
         }
         String datasource = publish.getDatasource();

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -103,7 +103,8 @@ public class ShareController {
         String requestUser = user.getId();
         String viewers = publish.getViewers();
         if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
-          AccessControlUtil.sendForbiddenError(response);
+          body.put("publishUser", publishUser);
+          body.put("accessDeniedFlag", true);
           return;
         }
         if (publishUser != null && publishUser.equals(requestUser)) {

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -103,7 +103,7 @@ public class ShareController {
         String requestUser = user.getId();
         String viewers = publish.getViewers();
         if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
-          AccessControlUtil.sendForbiddenError(response);
+          body.put("accessDeniedFlag", true);
           return;
         }
         if (publishUser != null && publishUser.equals(requestUser)) {

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -103,8 +103,7 @@ public class ShareController {
         String requestUser = user.getId();
         String viewers = publish.getViewers();
         if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
-          body.put("publishUser", publishUser);
-          AccessControlUtil.setForbiddenStatus(response);
+          AccessControlUtil.sendForbiddenError(response);
           return;
         }
         if (publishUser != null && publishUser.equals(requestUser)) {

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -103,7 +103,8 @@ public class ShareController {
         String requestUser = user.getId();
         String viewers = publish.getViewers();
         if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
-          AccessControlUtil.sendForbiddenError(response);
+          body.put("publishUser", publishUser);
+          AccessControlUtil.setForbiddenStatus(response);
           return;
         }
         if (publishUser != null && publishUser.equals(requestUser)) {

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -3,6 +3,7 @@ package yanagishima.controller;
 import static yanagishima.util.DownloadUtil.downloadCsv;
 import static yanagishima.util.DownloadUtil.downloadTsv;
 import static yanagishima.util.HistoryUtil.createHistoryResult;
+import static yanagishima.util.PublishUtil.canAccessPublishedPage;
 
 import java.util.HashMap;
 import java.util.List;
@@ -164,17 +165,5 @@ public class ShareController {
     event.put("user", user);
     event.put("viewers", viewers);
     fluencyClient.emitPublish(event);
-  }
-
-  private boolean canAccessPublishedPage(String publishUser, String requestUser, String viewers) {
-    if (publishUser != null && publishUser.equals(requestUser)) {
-      return true;
-    }
-
-    if (viewers != null && viewers.contains(requestUser)) {
-      return true;
-    }
-
-    return false;
   }
 }

--- a/src/main/java/yanagishima/model/db/Publish.java
+++ b/src/main/java/yanagishima/model/db/Publish.java
@@ -27,4 +27,7 @@ public class Publish {
   @Column(name = "user")
   private String user;
 
+  @Column(name = "viewers")
+  private String viewers;
+
 }

--- a/src/main/java/yanagishima/model/dto/PublishListDto.java
+++ b/src/main/java/yanagishima/model/dto/PublishListDto.java
@@ -1,0 +1,16 @@
+package yanagishima.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import yanagishima.model.db.Publish;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class PublishListDto {
+  @JsonProperty("publishList")
+  private List<Publish> publishList;
+  private String error;
+}

--- a/src/main/java/yanagishima/repository/PublishRepository.java
+++ b/src/main/java/yanagishima/repository/PublishRepository.java
@@ -3,6 +3,7 @@ package yanagishima.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,6 @@ public interface PublishRepository extends CrudRepository<Publish, String> {
 
   Optional<Publish> findByPublishId(String publishId);
 
-  List<Publish> findAllByDatasourceAndEngineAndUser(String datasource, String engine, String user);
+  List<Publish> findAllByDatasourceAndEngineAndUserOrderByQueryIdDesc(String datasource, String engine,
+                                                                      String user, Pageable pageable);
 }

--- a/src/main/java/yanagishima/repository/PublishRepository.java
+++ b/src/main/java/yanagishima/repository/PublishRepository.java
@@ -1,5 +1,6 @@
 package yanagishima.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
@@ -12,4 +13,6 @@ public interface PublishRepository extends CrudRepository<Publish, String> {
   Optional<Publish> findByDatasourceAndEngineAndQueryId(String datasource, String engine, String queryId);
 
   Optional<Publish> findByPublishId(String publishId);
+
+  List<Publish> findAllByDatasourceAndEngineAndUser(String datasource, String engine, String user);
 }

--- a/src/main/java/yanagishima/service/PublishService.java
+++ b/src/main/java/yanagishima/service/PublishService.java
@@ -38,4 +38,9 @@ public class PublishService {
     publish.setUser(user);
     return publishRepository.save(publish);
   }
+
+  public void update(Publish publish, String viewers) {
+    publish.setViewers(viewers);
+    publishRepository.save(publish);
+  }
 }

--- a/src/main/java/yanagishima/service/PublishService.java
+++ b/src/main/java/yanagishima/service/PublishService.java
@@ -2,6 +2,7 @@ package yanagishima.service;
 
 import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -22,6 +23,10 @@ public class PublishService {
 
   public Optional<Publish> get(String publishId) {
     return publishRepository.findByPublishId(publishId);
+  }
+
+  public List<Publish> getAll(String datasource, String engine, User user) {
+    return publishRepository.findAllByDatasourceAndEngineAndUser(datasource, engine, user.getId());
   }
 
   public Publish publish(String datasource, String engine, String queryId, User user) {

--- a/src/main/java/yanagishima/service/PublishService.java
+++ b/src/main/java/yanagishima/service/PublishService.java
@@ -5,6 +5,7 @@ import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,9 @@ public class PublishService {
     return publishRepository.findByPublishId(publishId);
   }
 
-  public List<Publish> getAll(String datasource, String engine, User user) {
-    return publishRepository.findAllByDatasourceAndEngineAndUser(datasource, engine, user.getId());
+  public List<Publish> getAll(String datasource, String engine, User user, int limit) {
+    return publishRepository.findAllByDatasourceAndEngineAndUserOrderByQueryIdDesc(datasource, engine,
+            user.getId(), PageRequest.of(0, limit));
   }
 
   public Publish publish(String datasource, String engine, String queryId, User user) {

--- a/src/main/java/yanagishima/util/AccessControlUtil.java
+++ b/src/main/java/yanagishima/util/AccessControlUtil.java
@@ -31,4 +31,8 @@ public final class AccessControlUtil {
       throw new RuntimeException(e);
     }
   }
+
+  public static void setForbiddenStatus(HttpServletResponse response) {
+    response.setStatus(SC_FORBIDDEN);
+  }
 }

--- a/src/main/java/yanagishima/util/AccessControlUtil.java
+++ b/src/main/java/yanagishima/util/AccessControlUtil.java
@@ -31,8 +31,4 @@ public final class AccessControlUtil {
       throw new RuntimeException(e);
     }
   }
-
-  public static void setForbiddenStatus(HttpServletResponse response) {
-    response.setStatus(SC_FORBIDDEN);
-  }
 }

--- a/src/main/java/yanagishima/util/PublishUtil.java
+++ b/src/main/java/yanagishima/util/PublishUtil.java
@@ -10,8 +10,12 @@ public final class PublishUtil {
             return true;
         }
 
-        if (viewers != null && viewers.contains(requestUser)) {
-            return true;
+        if (viewers != null) {
+            for (String viewer : viewers.split(",")) {
+                if (viewer.equals(requestUser)) {
+                    return true;
+                }
+            }
         }
 
         return false;

--- a/src/main/java/yanagishima/util/PublishUtil.java
+++ b/src/main/java/yanagishima/util/PublishUtil.java
@@ -1,0 +1,19 @@
+package yanagishima.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class PublishUtil {
+
+    public static boolean canAccessPublishedPage(String publishUser, String requestUser, String viewers) {
+        if (publishUser != null && publishUser.equals(requestUser)) {
+            return true;
+        }
+
+        if (viewers != null && viewers.contains(requestUser)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,6 +18,7 @@ datasource varchar(256),
 engine varchar(256),
 query_id varchar(256),
 user varchar(256),
+viewers text,
 primary key(publish_id))
 ;
 

--- a/src/test/java/yanagishima/util/PublishUtilTest.java
+++ b/src/test/java/yanagishima/util/PublishUtilTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class PublishUtilTest {
+class PublishUtilTest {
 
     @Test
     void testCanAccessPublishedPage() {

--- a/src/test/java/yanagishima/util/PublishUtilTest.java
+++ b/src/test/java/yanagishima/util/PublishUtilTest.java
@@ -1,0 +1,23 @@
+package yanagishima.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class PublishUtilTest {
+
+    @Test
+    void testCanAccessPublishedPage() {
+        assertTrue(PublishUtil.canAccessPublishedPage("jp11111", "jp11111",
+                "jp12345,jp67890"));
+        assertTrue(PublishUtil.canAccessPublishedPage("jp11111", "jp12345",
+                "jp12345,jp67890"));
+        assertFalse(PublishUtil.canAccessPublishedPage("jp11111", "jp99999",
+                "jp12345,jp67890"));
+        assertFalse(PublishUtil.canAccessPublishedPage(null, "jp99999",
+                "jp12345,jp67890"));
+        assertFalse(PublishUtil.canAccessPublishedPage("jp11111", "jp99999",
+                null));
+    }
+}

--- a/src/test/java/yanagishima/util/PublishUtilTest.java
+++ b/src/test/java/yanagishima/util/PublishUtilTest.java
@@ -19,5 +19,7 @@ class PublishUtilTest {
                 "jp12345,jp67890"));
         assertFalse(PublishUtil.canAccessPublishedPage("jp11111", "jp99999",
                 null));
+        assertFalse(PublishUtil.canAccessPublishedPage("jp11111", "jp1234",
+                "jp12345,jp67890"));
     }
 }


### PR DESCRIPTION
published page can only be accessed by publisher in default.

add column
```
alter table publish add viewers text;
```

There is no transformation in server-side but client-side will send commna separated viewr list log like bob,mark

audit log setting in application.yml
```
fluentd.publish.tag: applog.yanagishima.publish
```

sample fluentd log for auditing
```
2021-04-07 19:44:18.000000000 +0900 applog.yanagishima.publish: {"viewers":"bob,mark","query_id":"20210407_103117_01025_xsfyd","publish_id":"77dc3445a2ed3cf78f09d5cb3cf07df0","engine":"presto","datasource":"test","user":"alice"}
```