### PR TITLE
Set base package for swagger

### DIFF
--- a/src/main/java/yanagishima/config/SwaggerConfig.java
+++ b/src/main/java/yanagishima/config/SwaggerConfig.java
@@ -16,7 +16,7 @@ public class SwaggerConfig {
     return new Docket(DocumentationType.OAS_30)
         .useDefaultResponseMessages(false)
         .select()
-        .apis(RequestHandlerSelectors.any())
+        .apis(RequestHandlerSelectors.basePackage("yanagishima"))
         .paths(PathSelectors.regex("/.*"))
         .build()
         .apiInfo(new ApiInfoBuilder().title("Yanagishima").description("REST API for yanagishima").build());


### PR DESCRIPTION
Fix below error message during startup:
```
2021/05/16 11:12:58.212 +0900 ERROR [ApiDescriptionReader] [Yanagishima] Skipping process path[/actuator/beans], method[handle] as it has an error.
java.lang.NoClassDefFoundError: org/slf4j/event/Level
	at springfox.documentation.builders.ValidationResult.<init>(ValidationResult.java:12)
	at springfox.documentation.builders.ModelSpecificationBuilder.validateSpecification(ModelSpecificationBuilder.java:243)
	at springfox.documentation.builders.ModelSpecificationBuilder.build(ModelSpecificationBuilder.java:293)
	at springfox.documentation.builders.SimpleParameterSpecificationBuilder.build(SimpleParameterSpecificationBuilder.java:173)
	at springfox.documentation.builders.RequestParameterBuilder.build(RequestParameterBuilder.java:165)
	at springfox.documentation.spring.web.plugins.DocumentationPluginsManager.parameter(DocumentationPluginsManager.java:121)
	at springfox.documentation.spring.web.readers.operation.OperationParameterReader.readParameters(OperationParameterReader.java:126)
	at springfox.documentation.spring.web.readers.operation.OperationParameterReader.apply(OperationParameterReader.java:81)
	at springfox.documentation.spring.web.plugins.DocumentationPluginsManager.operation(DocumentationPluginsManager.java:144)
	at springfox.documentation.spring.web.readers.operation.ApiOperationReader.read(ApiOperationReader.java:72)
	at springfox.documentation.spring.web.scanners.CachingOperationReader.lambda$new$0(CachingOperationReader.java:43)
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1133)
...
```