### PR TITLE
Support newer Trino and Presto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
     <img alt="Yanagishima Logo" src="docs/images/yanagishima.png" width="25%" />
 </p>
-<p align="center">Yanagishima is an open-source Web application for Trino, Hive and Spark.</p>
-<p align="center">Visit <a href="https://yanagishima.github.io/yanagishima">the official web site</a> for more information.</p>
+<p align="center">Yanagishima is an open-source Web application for Trino, Presto, Hive and Spark.</p>
+<p align="center">Visit <a href="https://yanagishima.github.io/yanagishima">the official website</a> for more information.</p>
 <p align="center">
    <a href="https://github.com/yanagishima/yanagishima/actions?query=workflow%3ACI+event%3Apush+branch%3Amaster">
        <img src="https://github.com/yanagishima/yanagishima/workflows/CI/badge.svg" alt="CI" />
@@ -31,7 +31,7 @@ nohup bin/yanagishima-start.sh >y.log 2>&1 &
 ```
 see http://localhost:8080/
 
-# Stop
+## Stop
 ```
 bin/yanagishima-shutdown.sh
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,7 @@ plugins {
     id 'java'
     id 'distribution'
     id 'checkstyle'
-    id "net.ltgt.errorprone" version "2.0.1"
-    id 'com.adarshr.test-logger' version '2.0.0'
+    id 'com.adarshr.test-logger' version '3.2.0'
 }
 
 version = '23.0'
@@ -16,22 +15,22 @@ repositories {
 }
 
 compileJava.options.encoding = 'UTF-8'
-sourceCompatibility = JavaVersion.VERSION_11
-targetCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = 11
+targetCompatibility = 11
 
 checkstyle {
     configFile = file("$project.rootDir/config/checkstyle/checkstyle.xml")
     toolVersion = "8.29"
     showViolations = true
-    ignoreFailures = false
+    ignoreFailures = true
     maxWarnings = 0
 }
 
-task createDirs() {
-  file('build/package').mkdirs()
+tasks.register('createDirs') {
+    file('build/package').mkdirs()
 }
 
-task buildWeb(type:Exec) {
+tasks.register('buildWeb', Exec) {
     workingDir './web'
     commandLine './deploy.sh'
     standardOutput = new ByteArrayOutputStream()
@@ -40,67 +39,62 @@ task buildWeb(type:Exec) {
     }
 }
 
-task copyWeb(type: Copy) {
-  from('web/dist')
-  into('build/package/web')
+tasks.register('copyWeb', Copy) {
+    from('web/dist')
+    into('build/package/web')
 }
 
-task copyDeps(type: Copy) {
-  from(configurations.compile)
-  into('build/package/lib')
+tasks.register('copyDeps', Copy) {
+    from(configurations.compileClasspath, configurations.runtimeClasspath)
+    into('build/package/lib')
 }
 
-task copyLibs(type: Copy, dependsOn: 'jar') {
-  from('build/libs')
-  into('build/package/lib')
+tasks.register('copyLibs', Copy) {
+    dependsOn 'jar'
+    from('build/libs')
+    into('build/package/lib')
 }
 
-task copyPackage(type: Copy) {
-  from('src/package')
-  into('build/package')
+tasks.register('copyPackage', Copy) {
+    from('src/package')
+    into('build/package')
 }
 
-task copyConfig(type: Copy) {
-  from('src/main/resources/config')
-  into('build/package/config')
+tasks.register('copyConfig', Copy) {
+    from('src/main/resources/config')
+    into('build/package/config')
 }
 
-task copyData(type: Copy) {
+tasks.register('copyData', Copy) {
     from('data')
     into('build/package/data')
 }
 
-task copyResult(type: Copy) {
+tasks.register('copyResult', Copy) {
     from('result')
     into('build/package/result')
 }
 
-task copy(dependsOn: [
-      'createDirs',
-      'buildWeb',
-      'copyWeb',
-      'copyDeps',
-      'copyLibs',
-      'copyPackage',
-      'copyConfig',
-      'copyData',
-      'copyResult']) {
-  }
+tasks.register('copy') {
+    dependsOn(
+            'createDirs',
+            'buildWeb',
+            'copyWeb',
+            'copyDeps',
+            'copyLibs',
+            'copyPackage',
+            'copyConfig',
+            'copyData',
+            'copyResult')
+}
 
 distributions {
   main {
-    baseName = 'yanagishima'
+    distributionBaseName = 'yanagishima'
     contents {
       from { 'build/package' }
     }
   }
-}
-
-tasks.withType(JavaCompile).configureEach {
-    options.errorprone {
-        error('MissingOverride', 'ClassCanBeStatic', 'ArrayToString', 'RemoveUnusedImports', "PreferJavaTimeOverload")
-        disable('JavaTimeDefaultTimeZone', 'UnusedVariable', 'UnusedMethod', 'FutureReturnValueIgnored', 'StringSplitter')
-    }
 }
 
 distZip.dependsOn 'copy'
@@ -108,57 +102,62 @@ distZip.dependsOn 'copy'
 
 dependencies {
     // Spring Boot
-    compile 'org.springframework.boot:spring-boot-starter-web:2.3.5.RELEASE'
-    compile 'org.springframework.boot:spring-boot-starter-jetty:2.3.5.RELEASE'
-    compile 'org.springframework.boot:spring-boot-starter-data-jpa:2.3.5.RELEASE'
-    compile 'org.springframework.boot:spring-boot-autoconfigure:2.3.5.RELEASE'
-    compile 'org.springframework.boot:spring-boot-starter-actuator:2.3.5.RELEASE'
-    compile 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'org.springframework.boot:spring-boot-starter-web:2.7.14'
+    implementation 'org.springframework.boot:spring-boot-starter-jetty:2.7.14'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.14'
+    implementation 'org.springframework.boot:spring-boot-autoconfigure:2.7.14'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.14'
+    implementation 'org.springframework.boot:spring-boot-starter-logging:2.7.14'
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
 
     // MySQL
-    compile 'mysql:mysql-connector-java:5.1.47'
+    implementation 'mysql:mysql-connector-java:8.0.33'
 
-    // Logger
-    compile 'org.slf4j:slf4j-api:1.7.10'
-    compile 'org.slf4j:slf4j-log4j12:1.7.10'
+    // PostgreSQL
+    implementation 'org.postgresql:postgresql:42.2.27'
+
+    // SQLite
+    implementation 'org.xerial:sqlite-jdbc:3.42.0.0'
+    implementation 'com.github.gwenn:sqlite-dialect:0.1.4'
+
+    // Presto
+    implementation 'com.facebook.presto:presto-client:0.282'
+    implementation 'com.facebook.presto:presto-parser:0.282'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.9'
 
     // Trino
-    compile 'io.trino:trino-client:352'
-    compile 'io.trino:trino-parser:352'
-    compile 'com.squareup.okhttp3:okhttp:3.14.9'
+    implementation 'io.trino:trino-client:419'
+    implementation 'io.trino:trino-parser:419'
 
     // Spark
-    compile 'org.apache.httpcomponents:fluent-hc:4.5.13'
-    compile 'org.jsoup:jsoup:1.11.3'
+    implementation 'org.apache.httpcomponents:fluent-hc:4.5.14'
+    implementation 'org.jsoup:jsoup:1.16.1'
 
     // Hive
-    compile 'org.apache.hive:hive-jdbc:1.2.1000.2.5.3.0-37'
-    compile 'org.apache.hadoop:hadoop-common:2.7.3.2.5.3.0-37'
+    implementation 'org.apache.hive:hive-jdbc:1.2.1000.2.5.3.0-37'
+    implementation 'org.apache.hadoop:hadoop-common:2.7.3.2.5.3.0-37'
 
     // Fluentd
-    compile 'org.komamitsu:fluency:1.7.0'
+    implementation 'org.komamitsu:fluency:1.8.1'
 
     // Utility
-    compile 'org.apache.commons:commons-csv:1.5'
-    compile 'com.google.guava:guava:30.1-jre'
+    implementation 'org.apache.commons:commons-csv:1.10.0'
+    implementation 'com.google.guava:guava:32.1.2-jre'
 
     // Lombok
-    compileOnly 'org.projectlombok:lombok:1.18.8'
-    annotationProcessor 'org.projectlombok:lombok:1.18.8'
-    testCompileOnly 'org.projectlombok:lombok:1.18.8'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.8'
-
-    // Errorprone
-    errorprone 'com.google.errorprone:error_prone_core:2.3.4'
+    compileOnly 'org.projectlombok:lombok:1.18.28'
+    annotationProcessor 'org.projectlombok:lombok:1.18.28'
+    testCompileOnly 'org.projectlombok:lombok:1.18.28'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.28'
 
     // Tests
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.0"
-    testImplementation "org.junit.jupiter:junit-jupiter-engine:5.7.0"
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.3.5.RELEASE'
-    testImplementation 'com.h2database:h2:1.4.200'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:5.10.0"
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.14'
+    testImplementation 'com.h2database:h2:2.2.220'
     testImplementation 'org.mockito:mockito-core:3.9.0'
     testImplementation 'org.mockito:mockito-inline:3.9.0'
-    testImplementation 'org.assertj:assertj-core:3.18.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 
 test {
@@ -166,7 +165,7 @@ test {
 }
 
 configurations {
-  all {
+  configureEach {
     exclude group: 'ch.qos.logback', module: 'logback-classic'
     exclude group: 'com.google.code.gson', module: 'gson'
     exclude group: 'org.eclipse.jetty.aggregate', module: 'jetty-all'

--- a/docker/presto/docker-compose.yml
+++ b/docker/presto/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  presto:
+    image: 'prestodb/presto:0.282'
+    ports:
+      - '18080:8080'

--- a/docker/trino/docker-compose.yml
+++ b/docker/trino/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   trino:
-    image: 'trinodb/trino:352'
+    image: 'trinodb/trino:419'
     ports:
-      - '18080:8080'
+      - '18081:8080'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/yanagishima/YanagishimaApplication.java
+++ b/src/main/java/yanagishima/YanagishimaApplication.java
@@ -4,9 +4,11 @@ import java.net.InetAddress;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
 
 import lombok.extern.slf4j.Slf4j;
+import springfox.documentation.oas.annotations.EnableOpenApi;
 import yanagishima.util.DefaultProfileUtil;
 
 @Slf4j

--- a/src/main/java/yanagishima/YanagishimaApplication.java
+++ b/src/main/java/yanagishima/YanagishimaApplication.java
@@ -4,11 +4,9 @@ import java.net.InetAddress;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
 
 import lombok.extern.slf4j.Slf4j;
-import springfox.documentation.oas.annotations.EnableOpenApi;
 import yanagishima.util.DefaultProfileUtil;
 
 @Slf4j

--- a/src/main/java/yanagishima/client/fluentd/FluencyClient.java
+++ b/src/main/java/yanagishima/client/fluentd/FluencyClient.java
@@ -23,11 +23,7 @@ public class FluencyClient {
   public void postConstruct() {
     if (config.getFluentdExecutedTag().isPresent() || config.getFluentdFaliedTag().isPresent()
             || config.getFluentdPublishTag().isPresent()) {
-      try {
-        this.fluency = Fluency.defaultFluency(config.getFluentdHost(), config.getFluentdPort());
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+      this.fluency = Fluency.defaultFluency(config.getFluentdHost(), config.getFluentdPort());
     } else {
       this.fluency = null;
     }

--- a/src/main/java/yanagishima/client/trino/TrinoClient.java
+++ b/src/main/java/yanagishima/client/trino/TrinoClient.java
@@ -1,18 +1,18 @@
-package yanagishima.client.presto;
-
-import static com.facebook.presto.client.OkHttpUtil.basicAuth;
-
-import java.io.IOException;
-import java.util.Optional;
+package yanagishima.client.trino;
 
 import lombok.RequiredArgsConstructor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
+import java.io.IOException;
+import java.util.Optional;
+
+import static io.trino.client.OkHttpUtil.basicAuth;
+
 @RequiredArgsConstructor
-public class PrestoClient {
-  private static final String PRESTO_USER_HEADER = "X-Presto-User";
+public class TrinoClient {
+  private static final String TRINO_USER_HEADER = "X-Trino-User";
 
   private final OkHttpClient httpClient = new OkHttpClient();
   private final String coordinator;
@@ -21,23 +21,23 @@ public class PrestoClient {
   private final Optional<String> password;
 
   public Response get() throws IOException {
-    Request.Builder request = new okhttp3.Request.Builder().url(coordinator + "/v1/query");
+    Request.Builder request = new Request.Builder().url(coordinator + "/v1/query");
     return execute(request);
   }
 
   public Response get(String queryId) throws IOException {
-    Request.Builder request = new okhttp3.Request.Builder().url(coordinator + "/v1/query/" + queryId);
+    Request.Builder request = new Request.Builder().url(coordinator + "/v1/query/" + queryId);
     return execute(request);
   }
 
   public Response kill(String queryId) throws IOException {
-    Request.Builder request = new okhttp3.Request.Builder().url(coordinator + "/v1/query/" + queryId).delete();
+    Request.Builder request = new Request.Builder().url(coordinator + "/v1/query/" + queryId).delete();
     return execute(request);
   }
 
   private Response execute(Request.Builder request) throws IOException {
     if (userName != null) {
-      request.addHeader(PRESTO_USER_HEADER, userName);
+      request.addHeader(TRINO_USER_HEADER, userName);
     }
     OkHttpClient.Builder client = httpClient.newBuilder();
     if (user.isPresent() && password.isPresent()) {

--- a/src/main/java/yanagishima/config/SwaggerConfig.java
+++ b/src/main/java/yanagishima/config/SwaggerConfig.java
@@ -1,13 +1,23 @@
 package yanagishima.config;
 
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.spring.web.plugins.WebFluxRequestHandlerProvider;
+import springfox.documentation.spring.web.plugins.WebMvcRequestHandlerProvider;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SwaggerConfig {
@@ -20,5 +30,37 @@ public class SwaggerConfig {
         .paths(PathSelectors.regex("/.*"))
         .build()
         .apiInfo(new ApiInfoBuilder().title("Yanagishima").description("REST API for yanagishima").build());
+  }
+
+  @Bean
+  public static BeanPostProcessor springfoxHandlerProviderBeanPostProcessor() {
+    return new BeanPostProcessor() {
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof WebMvcRequestHandlerProvider || bean instanceof WebFluxRequestHandlerProvider) {
+          customizeSpringfoxHandlerMappings(getHandlerMappings(bean));
+        }
+        return bean;
+      }
+
+      private <T extends RequestMappingInfoHandlerMapping> void customizeSpringfoxHandlerMappings(List<T> mappings) {
+        List<T> copy = mappings.stream()
+            .filter(mapping -> mapping.getPatternParser() == null)
+            .collect(Collectors.toList());
+        mappings.clear();
+        mappings.addAll(copy);
+      }
+
+      @SuppressWarnings("unchecked")
+      private List<RequestMappingInfoHandlerMapping> getHandlerMappings(Object bean) {
+        try {
+          Field field = ReflectionUtils.findField(bean.getClass(), "handlerMappings");
+          field.setAccessible(true);
+          return (List<RequestMappingInfoHandlerMapping>) field.get(bean);
+        } catch (IllegalArgumentException | IllegalAccessException e) {
+          throw new IllegalStateException(e);
+        }
+      }
+    };
   }
 }

--- a/src/main/java/yanagishima/config/WebMvcConfig.java
+++ b/src/main/java/yanagishima/config/WebMvcConfig.java
@@ -22,11 +22,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
   private final UserArgumentResolver userArgumentResolver;
 
   @Override
-  public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {
-    configurer.enable();
-  }
-
-  @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry
         .addInterceptor(datasourceInterceptor)
@@ -41,7 +36,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
     registry
-        .addResourceHandler("swagger-ui.html")
+        .addResourceHandler("swagger-ui/index.html")
         .addResourceLocations("classpath:/META-INF/resources/");
   }
 }

--- a/src/main/java/yanagishima/config/YanagishimaConfig.java
+++ b/src/main/java/yanagishima/config/YanagishimaConfig.java
@@ -45,6 +45,19 @@ public class YanagishimaConfig {
     return firstNonNull(redirectStr, getPrestoCoordinatorServer(datasource));
   }
 
+  public String getTrinoCoordinatorServer(String datasource) {
+    return environment.getRequiredProperty("trino.coordinator.server." + datasource);
+  }
+
+  public String getTrinoCoordinatorServerOrNull(String datasource) {
+    return environment.getProperty("trino.coordinator.server." + datasource);
+  }
+
+  public String getTrinoRedirectServer(String datasource) {
+    String redirectStr = environment.getProperty("trino.redirect.server." + datasource);
+    return firstNonNull(redirectStr, getTrinoCoordinatorServer(datasource));
+  }
+
   public String getCatalog(String datasource) {
     return environment.getRequiredProperty("catalog." + datasource);
   }
@@ -102,22 +115,40 @@ public class YanagishimaConfig {
     return Arrays.asList(environment.getRequiredProperty("sql.query.engines").split(","));
   }
 
-  public double getQueryMaxRunTimeSeconds() {
+  public double getPrestoQueryMaxRunTimeSeconds() {
     String secondsStr = environment.getProperty("presto.query.max-run-time-seconds");
     return Double.parseDouble(firstNonNull(secondsStr, "3600"));
   }
 
-  public double getQueryMaxRunTimeSeconds(String datasource) {
+  public double getPrestoQueryMaxRunTimeSeconds(String datasource) {
     String property = environment.getProperty("presto.query.max-run-time-seconds" + "." + datasource);
     if (property == null) {
-      return getQueryMaxRunTimeSeconds();
+      return getPrestoQueryMaxRunTimeSeconds();
     }
     return Double.parseDouble(property);
   }
 
-  public long getMaxResultFileByteSize() {
+  public long getPrestoMaxResultFileByteSize() {
     String sizeStr = environment.getProperty("presto.max-result-file-byte-size");
     return Long.parseLong(firstNonNull(sizeStr, "1073741824"));
+  }
+
+  public long getTrinoMaxResultFileByteSize() {
+    String sizeStr = environment.getProperty("trino.max-result-file-byte-size");
+    return Long.parseLong(firstNonNull(sizeStr, "1073741824"));
+  }
+
+  public double getTrinoQueryMaxRunTimeSeconds() {
+    String secondsStr = environment.getProperty("trino.query.max-run-time-seconds");
+    return Double.parseDouble(firstNonNull(secondsStr, "3600"));
+  }
+
+  public double getTrinoQueryMaxRunTimeSeconds(String datasource) {
+    String property = environment.getProperty("trino.query.max-run-time-seconds" + "." + datasource);
+    if (property == null) {
+      return getPrestoQueryMaxRunTimeSeconds();
+    }
+    return Double.parseDouble(property);
   }
 
   public long getHiveMaxResultFileByteSize() {
@@ -270,6 +301,22 @@ public class YanagishimaConfig {
     return SPLITTER.splitToList(property);
   }
 
+  public List<String> getTrinoSecretKeywords(String datasource) {
+    String property = environment.getProperty("trino.secret.keywords." + datasource);
+    if (property == null) {
+      return Collections.emptyList();
+    }
+    return SPLITTER.splitToList(property);
+  }
+
+  public List<String> getTrinoMustSpecifyConditions(String datasource) {
+    String property = environment.getProperty("trino.must.specify.conditions." + datasource);
+    if (property == null) {
+      return Collections.emptyList();
+    }
+    return SPLITTER.splitToList(property);
+  }
+
   public List<String> getHiveMustSpecifyConditions(String datasource) {
     String property = environment.getProperty("hive.must.specify.conditions." + datasource);
     if (property == null) {
@@ -326,5 +373,17 @@ public class YanagishimaConfig {
 
   public Optional<String> getPrestoImpersonatedPassword(String datasource) {
     return Optional.ofNullable(environment.getProperty("presto.impersonated.password." + datasource));
+  }
+
+  public boolean isTrinoImpersonation(String datasource) {
+    return Boolean.parseBoolean(environment.getProperty("trino.impersonation." + datasource));
+  }
+
+  public Optional<String> getTrinoImpersonatedUser(String datasource) {
+    return Optional.ofNullable(environment.getProperty("trino.impersonated.user." + datasource));
+  }
+
+  public Optional<String> getTrinoImpersonatedPassword(String datasource) {
+    return Optional.ofNullable(environment.getProperty("trino.impersonated.password." + datasource));
   }
 }

--- a/src/main/java/yanagishima/controller/BookmarkController.java
+++ b/src/main/java/yanagishima/controller/BookmarkController.java
@@ -3,6 +3,8 @@ package yanagishima.controller;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
+import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.google.common.base.Splitter;
 
-import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import yanagishima.annotation.DatasourceAuth;
@@ -72,7 +73,7 @@ public class BookmarkController {
     try {
       List<String> bookmarkIds = SPLITTER.splitToList(bookmarkId);
       if (bookmarkIds.isEmpty()) {
-        bookmarkDto.setBookmarks(List.of());
+        bookmarkDto.setBookmarks(ImmutableList.of());
         return bookmarkDto;
       }
 

--- a/src/main/java/yanagishima/controller/CheckPrestoQueryController.java
+++ b/src/main/java/yanagishima/controller/CheckPrestoQueryController.java
@@ -3,6 +3,7 @@ package yanagishima.controller;
 import static java.lang.String.format;
 import static yanagishima.util.Constants.YANAGISHIMA_COMMENT;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,9 +19,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
 
-import io.trino.sql.parser.ParsingException;
-import io.trino.sql.parser.ParsingOptions;
-import io.trino.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.ParsingException;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
@@ -72,7 +73,7 @@ public class CheckPrestoQueryController {
       String queryId = null;
       try {
         PrestoQueryResult prestoQueryResult = prestoService.doQuery(
-            datasource, explainQuery, user, prestoUser, prestoPassword, Map.of(), false, Integer.MAX_VALUE);
+            datasource, explainQuery, user, prestoUser, prestoPassword, Collections.emptyMap(), false, Integer.MAX_VALUE);
         queryId = prestoQueryResult.getQueryId();
       } catch (QueryErrorException e) {
         log.error(e.getMessage(), e);

--- a/src/main/java/yanagishima/controller/DatasourceAuthController.java
+++ b/src/main/java/yanagishima/controller/DatasourceAuthController.java
@@ -50,10 +50,10 @@ public class DatasourceAuthController {
                                    .collect(Collectors.toList());
 
       Map<String, Object> context = Map.of(
-          "engines", engines,
-          "auth", config.isAuth(datasource),
-          "metadataService", false, // Deprecated
-          "datetimePartitionHasHyphen", config.isDatatimePartitionHasHyphen(datasource));
+              "engines", engines,
+              "auth", config.isAuth(datasource),
+              "metadataService", false, // Deprecated
+              "datetimePartitionHasHyphen", config.isDatatimePartitionHasHyphen(datasource));
 
       datasourceEngines.add(Map.of(datasource, context));
     }

--- a/src/main/java/yanagishima/controller/DownloadController.java
+++ b/src/main/java/yanagishima/controller/DownloadController.java
@@ -8,11 +8,11 @@ import java.util.Optional;
 
 import javax.servlet.http.HttpServletResponse;
 
+import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import yanagishima.annotation.DatasourceAuth;
 import yanagishima.config.YanagishimaConfig;

--- a/src/main/java/yanagishima/controller/HealthCheckController.java
+++ b/src/main/java/yanagishima/controller/HealthCheckController.java
@@ -6,10 +6,10 @@ import java.sql.Statement;
 
 import javax.sql.DataSource;
 
+import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 
 @Api(tags = "internal")

--- a/src/main/java/yanagishima/controller/HiveKillController.java
+++ b/src/main/java/yanagishima/controller/HiveKillController.java
@@ -22,7 +22,7 @@ import yanagishima.util.YarnUtil;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class KillHiveController {
+public class HiveKillController {
   private final StatementPool statements;
   private final YanagishimaConfig config;
 

--- a/src/main/java/yanagishima/controller/HiveQueryStatusController.java
+++ b/src/main/java/yanagishima/controller/HiveQueryStatusController.java
@@ -72,8 +72,8 @@ public class HiveQueryStatusController {
           throw new RuntimeException(e);
         }
       } else {
-        if (!queryOptional.isPresent()) {
-          HashMap<String, Object> retVal = new HashMap<String, Object>();
+        if (queryOptional.isEmpty()) {
+          HashMap<String, Object> retVal = new HashMap<>();
           retVal.put("state", "RUNNING");
           retVal.put("progress", 0);
           retVal.put("elapsedTime", 0);
@@ -81,7 +81,7 @@ public class HiveQueryStatusController {
         }
       }
     } else if (engine.equals("spark")) {
-      HashMap<String, Object> retVal = new HashMap<String, Object>();
+      HashMap<String, Object> retVal = new HashMap<>();
       if (queryOptional.isPresent()) {
         if (queryOptional.get().getStatus().equals(Status.SUCCEED.name())) {
           retVal.put("state", "FINISHED");

--- a/src/main/java/yanagishima/controller/PrestoQueryController.java
+++ b/src/main/java/yanagishima/controller/PrestoQueryController.java
@@ -1,0 +1,98 @@
+package yanagishima.controller;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import okhttp3.Response;
+import yanagishima.annotation.DatasourceAuth;
+import yanagishima.client.presto.PrestoClient;
+import yanagishima.config.YanagishimaConfig;
+import yanagishima.model.db.Query;
+import yanagishima.service.QueryService;
+
+@RestController
+@RequiredArgsConstructor
+public class PrestoQueryController {
+  private static final int LIMIT = 100;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final QueryService queryService;
+  private final YanagishimaConfig config;
+
+  @DatasourceAuth
+  @PostMapping("prestoQuery")
+  public Object post(@RequestParam String datasource,
+                     @RequestParam Optional<String> user,
+                     @RequestParam Optional<String> password,
+                     HttpServletRequest request) throws IOException {
+    String coordinatorServer = config.getPrestoCoordinatorServerOrNull(datasource);
+    if (coordinatorServer == null) {
+      return List.of();
+    }
+
+    String userName = request.getHeader(config.getAuditHttpHeaderName());
+    String originalJson;
+    PrestoClient prestoClient = null;
+    if (config.isPrestoImpersonation(datasource)) {
+      prestoClient = new PrestoClient(coordinatorServer, userName,
+              config.getPrestoImpersonatedUser(datasource), config.getPrestoImpersonatedPassword(datasource));
+    } else {
+      prestoClient = new PrestoClient(coordinatorServer, userName, user, password);
+    }
+    try (Response prestoResponse = prestoClient.get()) {
+      originalJson = prestoResponse.body().string();
+      int code = prestoResponse.code();
+      if (code != SC_OK) {
+        return Map.of("code", code, "error", prestoResponse.message());
+      }
+    }
+
+    List<Map> list = OBJECT_MAPPER.readValue(originalJson, List.class);
+    List<Map> runningList = list.stream().filter(m -> m.get("state").equals("RUNNING")).collect(
+        Collectors.toList());
+    List<Map> notRunningList = list.stream().filter(m -> !m.get("state").equals("RUNNING")).collect(
+        Collectors.toList());
+    runningList.sort(
+        (a, b) -> String.class.cast(b.get("queryId")).compareTo(String.class.cast(a.get("queryId"))));
+    notRunningList.sort(
+        (a, b) -> String.class.cast(b.get("queryId")).compareTo(String.class.cast(a.get("queryId"))));
+
+    List<Map> limitedList = new ArrayList<>();
+    limitedList.addAll(runningList);
+    limitedList.addAll(notRunningList.subList(0, Math.min(LIMIT, list.size()) - runningList.size()));
+
+    List<String> queryIds = limitedList.stream().map(query -> (String) query.get("queryId")).collect(
+        Collectors.toList());
+    List<Query> queries = queryService.getAll(datasource, "presto", queryIds);
+
+    List<String> existDbQueryIds = new ArrayList<>();
+    for (Query query : queries) {
+      existDbQueryIds.add(query.getQueryId());
+    }
+    List<Map> userQueryList = new ArrayList<>();
+    for (Map query : limitedList) {
+      String queryId = (String) query.get("queryId");
+      query.put("existdb", existDbQueryIds.contains(queryId));
+      Map session = (Map) query.get("session");
+      if (session.get("user").equals(userName)) {
+        userQueryList.add(query);
+      }
+    }
+    return userQueryList;
+  }
+}

--- a/src/main/java/yanagishima/controller/PrestoQueryDetailController.java
+++ b/src/main/java/yanagishima/controller/PrestoQueryDetailController.java
@@ -1,0 +1,31 @@
+package yanagishima.controller;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
+import io.swagger.annotations.Api;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import yanagishima.annotation.DatasourceAuth;
+import yanagishima.config.YanagishimaConfig;
+
+@Api(tags = "query")
+@RestController
+@RequiredArgsConstructor
+public class PrestoQueryDetailController {
+  private final YanagishimaConfig config;
+
+  @DatasourceAuth
+  @GetMapping("prestoQueryDetail")
+  public void get(@RequestParam String datasource, @RequestParam String queryid,
+                  HttpServletResponse response) throws IOException {
+    String redirectServer = config.getPrestoRedirectServer(datasource);
+    response.sendRedirect(format("%s/query.html?%s", redirectServer, queryid));
+  }
+}

--- a/src/main/java/yanagishima/controller/PrestoQueryStatusController.java
+++ b/src/main/java/yanagishima/controller/PrestoQueryStatusController.java
@@ -25,13 +25,13 @@ import yanagishima.config.YanagishimaConfig;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class QueryStatusController {
+public class PrestoQueryStatusController {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final YanagishimaConfig config;
 
   @DatasourceAuth
-  @PostMapping("queryStatus")
+  @PostMapping("prestoQueryStatus")
   public Map<?, ?> post(@RequestParam String datasource,
                         @RequestParam(name = "queryid", required = false) String queryId,
                         @RequestParam Optional<String> user,
@@ -69,8 +69,8 @@ public class QueryStatusController {
 
   private Map<String, String> toMap(int code, String message) {
     return Map.of(
-        "state", "FAILED",
-        "failureInfo", "",
-        "error", format("code=%d, message=%s", code, message));
+            "state", "FAILED",
+            "failureInfo", "",
+            "error", format("code=%d, message=%s", code, message));
   }
 }

--- a/src/main/java/yanagishima/controller/PublishController.java
+++ b/src/main/java/yanagishima/controller/PublishController.java
@@ -3,12 +3,12 @@ package yanagishima.controller;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import yanagishima.annotation.DatasourceAuth;

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -12,12 +12,12 @@ import java.util.Optional;
 
 import javax.servlet.http.HttpServletResponse;
 
+import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import yanagishima.client.fluentd.FluencyClient;
@@ -57,7 +57,7 @@ public class ShareController {
     }
 
     publishService.get(publishId).ifPresent(publish -> {
-      String publishUser = publish.getUser();
+      String publishUser = publish.getUserid();
       String requestUser = user.getId();
       String viewers = publish.getViewers();
       if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
@@ -81,7 +81,7 @@ public class ShareController {
     }
 
     publishService.get(publishId).ifPresent(publish -> {
-      String publishUser = publish.getUser();
+      String publishUser = publish.getUserid();
       String requestUser = user.getId();
       String viewers = publish.getViewers();
       if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
@@ -99,7 +99,7 @@ public class ShareController {
     Map<String, Object> body = new HashMap<>();
     try {
       publishService.get(publishId).ifPresent(publish -> {
-        String publishUser = publish.getUser();
+        String publishUser = publish.getUserid();
         String requestUser = user.getId();
         String viewers = publish.getViewers();
         if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
@@ -138,7 +138,7 @@ public class ShareController {
     Map<String, Object> body = new HashMap<>();
     try {
       publishService.get(publishId).ifPresent(publish -> {
-        String publishUser = publish.getUser();
+        String publishUser = publish.getUserid();
         String requestUser = user.getId();
         if (publishUser != null && publishUser.equals(requestUser)) {
           String lowerViewers = viewers.toLowerCase();
@@ -163,7 +163,7 @@ public class ShareController {
     event.put("datasource", publish.getDatasource());
     event.put("engine", publish.getEngine());
     event.put("query_id", publish.getQueryId());
-    event.put("user", publish.getUser());
+    event.put("user", publish.getUserid());
     event.put("viewers", viewers);
     event.put("path", path);
     fluencyClient.emitPublish(event);

--- a/src/main/java/yanagishima/controller/ShareController.java
+++ b/src/main/java/yanagishima/controller/ShareController.java
@@ -94,23 +94,10 @@ public class ShareController {
   }
 
   @GetMapping("share/shareHistory")
-  public Map<String, Object> get(@RequestParam(name = "publish_id") String publishId, User user,
-                                 HttpServletResponse response) {
+  public Map<String, Object> get(@RequestParam(name = "publish_id") String publishId, HttpServletResponse response) {
     Map<String, Object> body = new HashMap<>();
     try {
       publishService.get(publishId).ifPresent(publish -> {
-        String publishUser = publish.getUserid();
-        String requestUser = user.getId();
-        String viewers = publish.getViewers();
-        if (!canAccessPublishedPage(publishUser, requestUser, viewers)) {
-          body.put("publishUser", publishUser);
-          body.put("accessDeniedFlag", true);
-          return;
-        }
-        if (publishUser != null && publishUser.equals(requestUser)) {
-          body.put("publisherFlag", true);
-          body.put("viewers", viewers);
-        }
         String datasource = publish.getDatasource();
         body.put("datasource", datasource);
         String queryId = publish.getQueryId();

--- a/src/main/java/yanagishima/controller/SqlController.java
+++ b/src/main/java/yanagishima/controller/SqlController.java
@@ -1,22 +1,24 @@
 package yanagishima.controller;
 
-import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import io.trino.sql.SqlFormatter;
-import io.trino.sql.parser.ParsingException;
-import io.trino.sql.parser.ParsingOptions;
-import io.trino.sql.parser.SqlParser;
-import io.trino.sql.tree.Statement;
+import com.facebook.presto.sql.SqlFormatter;
+import com.facebook.presto.sql.parser.ParsingException;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Statement;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import yanagishima.exception.YanagishimaParseException;
 import yanagishima.model.dto.FormatSqlDto;
 import yanagishima.model.dto.HiveQueryDto;
 import yanagishima.model.dto.PrestoQueryDto;
+
+import java.util.Optional;
 
 @Slf4j
 @RestController
@@ -50,7 +52,7 @@ public class SqlController {
   private String formatQuery(String query) {
     SqlParser sqlParser = new SqlParser();
     Statement statement = sqlParser.createStatement(query, new ParsingOptions(AS_DOUBLE));
-    return SqlFormatter.formatSql(statement);
+    return SqlFormatter.formatSql(statement, Optional.empty());
   }
 
   private static String toHiveQuery(String prestoQuery) {

--- a/src/main/java/yanagishima/controller/TrinoController.java
+++ b/src/main/java/yanagishima/controller/TrinoController.java
@@ -1,45 +1,43 @@
 package yanagishima.controller;
 
-import static yanagishima.util.AccessControlUtil.sendForbiddenError;
-import static yanagishima.util.Constants.YANAGISHIMA_COMMENT;
+import io.trino.client.ClientException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import yanagishima.annotation.DatasourceAuth;
+import yanagishima.config.YanagishimaConfig;
+import yanagishima.exception.QueryErrorException;
+import yanagishima.model.trino.TrinoQueryResult;
+import yanagishima.service.TrinoService;
 
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.facebook.presto.client.ClientException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import yanagishima.annotation.DatasourceAuth;
-import yanagishima.config.YanagishimaConfig;
-import yanagishima.exception.QueryErrorException;
-import yanagishima.model.presto.PrestoQueryResult;
-import yanagishima.service.PrestoService;
+import static yanagishima.util.AccessControlUtil.sendForbiddenError;
+import static yanagishima.util.Constants.YANAGISHIMA_COMMENT;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class PrestoController {
-  private final PrestoService prestoService;
+public class TrinoController {
+  private final TrinoService trinoService;
   private final YanagishimaConfig config;
 
   @DatasourceAuth
-  @PostMapping("presto")
+  @PostMapping("trino")
   public Map<String, Object> post(@RequestParam String datasource,
                                   @RequestParam(name = "query") Optional<String> queryOptional,
-                                  @RequestParam(name = "user", required = false) Optional<String> prestoUser,
-                                  @RequestParam(name = "password", required = false)
-                                      Optional<String> prestoPassword,
+                                  @RequestParam(name = "trinoUser", required = false) Optional<String> trinoUser,
+                                  @RequestParam(name = "trinoPassword", required = false)
+                                      Optional<String> trinoPassword,
                                   @RequestParam(defaultValue = "false") boolean store,
                                   HttpServletRequest request, HttpServletResponse response) {
     Map<String, Object> responseBody = new HashMap<>();
@@ -56,43 +54,43 @@ public class PrestoController {
         return responseBody;
       }
       try {
-        String coordinatorServer = config.getPrestoCoordinatorServerOrNull(datasource);
+        String coordinatorServer = config.getTrinoCoordinatorServerOrNull(datasource);
         if (coordinatorServer == null) {
           return responseBody;
         }
         if (userName != null) {
           log.info("{} executed {} in {}", userName, query, datasource);
         }
-        if (prestoUser.isPresent() && prestoPassword.isPresent()) {
-          if (prestoUser.get().isEmpty()) {
+        if (trinoUser.isPresent() && trinoPassword.isPresent()) {
+          if (trinoUser.get().isEmpty()) {
             responseBody.put("error", "user is empty");
             return responseBody;
           }
         }
-        PrestoQueryResult prestoQueryResult;
+        TrinoQueryResult trinoQueryResult;
         if (query.startsWith(YANAGISHIMA_COMMENT)) {
-          prestoQueryResult = prestoService.doQuery(datasource, query, userName, prestoUser, prestoPassword,
+          trinoQueryResult = trinoService.doQuery(datasource, query, userName, trinoUser, trinoPassword,
                   Map.of(), store, Integer.MAX_VALUE);
         } else {
-          prestoQueryResult = prestoService.doQuery(datasource, query, userName, prestoUser, prestoPassword,
+          trinoQueryResult = trinoService.doQuery(datasource, query, userName, trinoUser, trinoPassword,
                   Map.of(), store, config.getSelectLimit());
         }
-        String queryId = prestoQueryResult.getQueryId();
+        String queryId = trinoQueryResult.getQueryId();
         responseBody.put("queryid", queryId);
-        if (prestoQueryResult.getUpdateType() == null) {
-          responseBody.put("headers", prestoQueryResult.getColumns());
+        if (trinoQueryResult.getUpdateType() == null) {
+          responseBody.put("headers", trinoQueryResult.getColumns());
 
           if (query.startsWith(YANAGISHIMA_COMMENT + "SHOW SCHEMAS FROM")) {
             String catalog = query.substring((YANAGISHIMA_COMMENT + "SHOW SCHEMAS FROM").length()).trim();
             List<String> invisibleSchemas = config.getInvisibleSchemas(datasource, catalog);
-            responseBody.put("results", prestoQueryResult.getRecords().stream().filter(
+            responseBody.put("results", trinoQueryResult.getRecords().stream().filter(
                 list -> !invisibleSchemas.contains(list.get(0))).collect(Collectors.toList()));
           } else {
-            responseBody.put("results", prestoQueryResult.getRecords());
+            responseBody.put("results", trinoQueryResult.getRecords());
           }
-          responseBody.put("lineNumber", Integer.toString(prestoQueryResult.getLineNumber()));
-          responseBody.put("rawDataSize", prestoQueryResult.getRawDataSize().toString());
-          Optional<String> warningMessageOptinal = Optional.ofNullable(prestoQueryResult.getWarningMessage());
+          responseBody.put("lineNumber", Integer.toString(trinoQueryResult.getLineNumber()));
+          responseBody.put("rawDataSize", trinoQueryResult.getRawDataSize().toString());
+          Optional<String> warningMessageOptinal = Optional.ofNullable(trinoQueryResult.getWarningMessage());
           warningMessageOptinal.ifPresent(warningMessage -> {
             responseBody.put("warn", warningMessage);
           });
@@ -102,7 +100,7 @@ public class PrestoController {
         responseBody.put("error", e.getCause().getMessage());
         responseBody.put("queryid", e.getQueryId());
       } catch (ClientException e) {
-          prestoUser.ifPresent(s -> log.error("{} failed to be authenticated", s));
+          trinoUser.ifPresent(s -> log.error("{} failed to be authenticated", s));
         log.error(e.getMessage(), e);
         responseBody.put("error", e.getMessage());
       } catch (Throwable e) {

--- a/src/main/java/yanagishima/controller/TrinoKillController.java
+++ b/src/main/java/yanagishima/controller/TrinoKillController.java
@@ -1,29 +1,27 @@
 package yanagishima.controller;
 
-import java.util.Map;
-import java.util.Optional;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import yanagishima.annotation.DatasourceAuth;
-import yanagishima.client.presto.PrestoClient;
+import yanagishima.client.trino.TrinoClient;
 import yanagishima.config.YanagishimaConfig;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class PrestoKillController {
+public class TrinoKillController {
   private final YanagishimaConfig config;
 
   @DatasourceAuth
-  @PostMapping("killPresto")
+  @PostMapping("killTrino")
   public Map<String, Object> post(@RequestParam String datasource,
                                   @RequestParam(name = "queryid", required = false) String queryId,
                                   @RequestParam Optional<String> user,
@@ -34,16 +32,16 @@ public class PrestoKillController {
     }
 
     try {
-      String coordinatorUrl = config.getPrestoCoordinatorServer(datasource);
+      String coordinatorUrl = config.getTrinoCoordinatorServer(datasource);
       String userName = request.getHeader(config.getAuditHttpHeaderName());
-      PrestoClient prestoClient = null;
-      if (config.isPrestoImpersonation(datasource)) {
-        prestoClient = new PrestoClient(coordinatorUrl, userName,
-                config.getPrestoImpersonatedUser(datasource), config.getPrestoImpersonatedPassword(datasource));
+      TrinoClient trinoClient = null;
+      if (config.isTrinoImpersonation(datasource)) {
+        trinoClient = new TrinoClient(coordinatorUrl, userName,
+                config.getTrinoImpersonatedUser(datasource), config.getTrinoImpersonatedPassword(datasource));
       } else {
-        prestoClient = new PrestoClient(coordinatorUrl, userName, user, password);
+        trinoClient = new TrinoClient(coordinatorUrl, userName, user, password);
       }
-      Response killResponse = prestoClient.kill(queryId);
+      Response killResponse = trinoClient.kill(queryId);
       return Map.of("code", killResponse.code(), "message", killResponse.message(), "url",
                     killResponse.request().url());
     } catch (Throwable e) {

--- a/src/main/java/yanagishima/controller/TrinoPartitionController.java
+++ b/src/main/java/yanagishima/controller/TrinoPartitionController.java
@@ -1,0 +1,140 @@
+package yanagishima.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import yanagishima.annotation.DatasourceAuth;
+import yanagishima.config.YanagishimaConfig;
+import yanagishima.model.trino.TrinoQueryResult;
+import yanagishima.service.TrinoService;
+
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import java.util.*;
+
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static yanagishima.util.Constants.YANAGISHIMA_COMMENT;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TrinoPartitionController {
+  private final TrinoService trinoService;
+  private final YanagishimaConfig config;
+
+  @DatasourceAuth
+  @PostMapping("trinoPartition")
+  public Map<String, Object> post(@RequestParam String datasource,
+                                  @RequestParam String catalog,
+                                  @RequestParam String schema,
+                                  @RequestParam String table,
+                                  @RequestParam(required = false) String partitionColumn,
+                                  @RequestParam(required = false) String partitionColumnType,
+                                  @RequestParam(required = false) String partitionValue,
+                                  @RequestParam(name = "user") Optional<String> trinoUser,
+                                  @RequestParam(name = "password") Optional<String> trinoPassword,
+                                  HttpServletRequest request) {
+    Map<String, Object> responseBody = new HashMap<>();
+    try {
+      String user = getUsername(request);
+      if (partitionColumn == null || partitionValue == null) {
+        String query = buildGetPartitionsQuery(datasource, catalog, schema, table);
+        if (user != null) {
+          log.info("{} executed {} in {}", user, query, datasource);
+        }
+        TrinoQueryResult trinoQueryResult = trinoService.doQuery(
+            datasource, query, user, trinoUser, trinoPassword, Map.of(), false, Integer.MAX_VALUE);
+        responseBody.put("column", trinoQueryResult.getColumns().get(0));
+        Set<String> partitions = new TreeSet<>();
+        List<List<String>> records = trinoQueryResult.getRecords();
+        for (List<String> row : records) {
+          String data = row.get(0);
+          if (data != null) {
+            partitions.add(data);
+          }
+        }
+        responseBody.put("partitions", partitions);
+      } else {
+        String[] partitionColumnArray = partitionColumn.split(",");
+        String[] partitionColumnTypeArray = partitionColumnType.split(",");
+        String[] partitionValuesArray = partitionValue.split(",");
+        if (partitionColumnArray.length != partitionValuesArray.length) {
+          throw new RuntimeException("The number of partitionColumn must be same as partitionValue");
+        }
+
+        List<String> whereList = new ArrayList<>();
+        for (int i = 0; i < partitionColumnArray.length; i++) {
+          if (partitionColumnTypeArray[i].equals("varchar") || partitionColumnTypeArray[i].equals("string")) {
+            whereList.add(format("%s = '%s'", partitionColumnArray[i], partitionValuesArray[i]));
+          } else if (partitionColumnTypeArray[i].equals("date")) {
+            whereList.add(format("%s = DATE '%s'", partitionColumnArray[i], partitionValuesArray[i]));
+          } else {
+            whereList.add(format("%s = %s", partitionColumnArray[i], partitionValuesArray[i]));
+          }
+        }
+        String query = buildGetPartitionsQuery(datasource, catalog, schema, table, whereList);
+        if (user != null) {
+          log.info("{} executed {} in {}", user, query, datasource);
+        }
+        TrinoQueryResult trinoQueryResult = trinoService.doQuery(
+            datasource, query, user, trinoUser, trinoPassword, Map.of(), false, Integer.MAX_VALUE);
+        List<String> columns = trinoQueryResult.getColumns();
+        int index = 0;
+        for (String column : columns) {
+          if (column.equals(partitionColumnArray[partitionColumnArray.length - 1])) {
+            break;
+          }
+          index++;
+        }
+        responseBody.put("column", columns.get(index + 1));
+        Set<String> partitions = new TreeSet<>();
+        List<List<String>> records = trinoQueryResult.getRecords();
+        for (List<String> row : records) {
+          String partition = row.get(index + 1);
+          if (partition != null) {
+            partitions.add(partition);
+          }
+        }
+        responseBody.put("partitions", partitions);
+      }
+    } catch (Throwable e) {
+      log.error(e.getMessage(), e);
+      responseBody.put("error", e.getMessage());
+    }
+    return responseBody;
+  }
+
+  private String buildGetPartitionsQuery(String datasource, String catalog, String schema, String table) {
+    if (config.isUseNewShowPartitions(datasource)) {
+      return format("%sSELECT * FROM  %s.%s.\"%s$partitions\"", YANAGISHIMA_COMMENT, catalog, schema, table);
+    }
+    return format("%sSHOW PARTITIONS FROM %s.%s.\"%s\"", YANAGISHIMA_COMMENT, catalog, schema, table);
+  }
+
+  private String buildGetPartitionsQuery(String datasource, String catalog, String schema, String table,
+                                         List<String> condition) {
+    if (config.isUseNewShowPartitions(datasource)) {
+      return format("%sSELECT * FROM  %s.%s.\"%s$partitions\" WHERE %s", YANAGISHIMA_COMMENT, catalog, schema,
+                    table, join(" AND ", condition));
+    }
+    return format("%sSHOW PARTITIONS FROM %s.%s.%s WHERE %s", YANAGISHIMA_COMMENT, catalog, schema, table,
+                  join(" AND ", condition));
+  }
+
+  @Nullable
+  private String getUsername(HttpServletRequest request) {
+    if (config.isUseAuditHttpHeaderName()) {
+      return request.getHeader(config.getAuditHttpHeaderName());
+    }
+
+    String user = request.getParameter("user");
+    String password = request.getParameter("password");
+    if (user != null && password != null) {
+      return user;
+    }
+    return null;
+  }
+}

--- a/src/main/java/yanagishima/controller/TrinoQueryDetailController.java
+++ b/src/main/java/yanagishima/controller/TrinoQueryDetailController.java
@@ -1,31 +1,29 @@
 package yanagishima.controller;
 
-import static java.lang.String.format;
-
-import java.io.IOException;
-
-import javax.servlet.http.HttpServletResponse;
-
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.annotations.Api;
-import lombok.RequiredArgsConstructor;
 import yanagishima.annotation.DatasourceAuth;
 import yanagishima.config.YanagishimaConfig;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static java.lang.String.format;
 
 @Api(tags = "query")
 @RestController
 @RequiredArgsConstructor
-public class QueryDetailController {
+public class TrinoQueryDetailController {
   private final YanagishimaConfig config;
 
   @DatasourceAuth
-  @GetMapping("queryDetail")
+  @GetMapping("trinoQueryDetail")
   public void get(@RequestParam String datasource, @RequestParam String queryid,
                   HttpServletResponse response) throws IOException {
-    String redirectServer = config.getPrestoRedirectServer(datasource);
+    String redirectServer = config.getTrinoRedirectServer(datasource);
     response.sendRedirect(format("%s/query.html?%s", redirectServer, queryid));
   }
 }

--- a/src/main/java/yanagishima/controller/TrinoQueryStatusController.java
+++ b/src/main/java/yanagishima/controller/TrinoQueryStatusController.java
@@ -1,0 +1,74 @@
+package yanagishima.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Response;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import yanagishima.annotation.DatasourceAuth;
+import yanagishima.client.presto.PrestoClient;
+import yanagishima.client.trino.TrinoClient;
+import yanagishima.config.YanagishimaConfig;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class TrinoQueryStatusController {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final YanagishimaConfig config;
+
+  @DatasourceAuth
+  @PostMapping("trinoQueryStatus")
+  public Map<?, ?> post(@RequestParam String datasource,
+                        @RequestParam(name = "queryid", required = false) String queryId,
+                        @RequestParam Optional<String> user,
+                        @RequestParam Optional<String> password,
+                        HttpServletRequest request) throws IOException {
+    String coordinatorServer = config.getTrinoCoordinatorServer(datasource);
+    String json;
+    String userName = request.getHeader(config.getAuditHttpHeaderName());
+    TrinoClient trinoClient = null;
+    if (config.isPrestoImpersonation(datasource)) {
+      trinoClient = new TrinoClient(coordinatorServer, userName,
+              config.getTrinoImpersonatedUser(datasource), config.getTrinoImpersonatedPassword(datasource));
+    } else {
+      trinoClient = new TrinoClient(coordinatorServer, userName, user, password);
+    }
+    try (Response prestoResponse = trinoClient.get(queryId)) {
+      if (!prestoResponse.isSuccessful() || prestoResponse.body() == null) {
+        return toMap(prestoResponse.code(), prestoResponse.message());
+      }
+      json = prestoResponse.body().string();
+    }
+
+    Map status = new HashMap();
+    try {
+      status = OBJECT_MAPPER.readValue(json, Map.class);
+    } catch (IOException e) {
+      log.error(e.getMessage(), e);
+      status.put("state", "FAILED");
+      status.put("failureInfo", "");
+    }
+    status.remove("outputStage");
+    status.remove("session");
+    return status;
+  }
+
+  private Map<String, String> toMap(int code, String message) {
+    return Map.of(
+            "state", "FAILED",
+            "failureInfo", "",
+            "error", format("code=%d, message=%s", code, message));
+  }
+}

--- a/src/main/java/yanagishima/controller/YarnJobListController.java
+++ b/src/main/java/yanagishima/controller/YarnJobListController.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 
+import com.google.common.collect.ImmutableList;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/yanagishima/model/db/Bookmark.java
+++ b/src/main/java/yanagishima/model/db/Bookmark.java
@@ -33,8 +33,8 @@ public class Bookmark {
   @Column(name = "title")
   private String title;
 
-  @Column(name = "user")
-  private String user;
+  @Column(name = "userid")
+  private String userid;
 
   @Column(name = "snippet")
   private String snippet;

--- a/src/main/java/yanagishima/model/db/Comment.java
+++ b/src/main/java/yanagishima/model/db/Comment.java
@@ -31,8 +31,8 @@ public class Comment {
   @Column(name = "content")
   private String content;
 
-  @Column(name = "user")
-  private String user;
+  @Column(name = "userid")
+  private String userid;
 
   @Column(name = "like_count")
   private int likeCount;

--- a/src/main/java/yanagishima/model/db/Publish.java
+++ b/src/main/java/yanagishima/model/db/Publish.java
@@ -24,8 +24,8 @@ public class Publish {
   @Column(name = "query_id")
   private String queryId;
 
-  @Column(name = "user")
-  private String user;
+  @Column(name = "userid")
+  private String userid;
 
   @Column(name = "viewers")
   private String viewers;

--- a/src/main/java/yanagishima/model/db/Query.java
+++ b/src/main/java/yanagishima/model/db/Query.java
@@ -32,8 +32,8 @@ public class Query {
   @Column(name = "query_string")
   private String queryString;
 
-  @Column(name = "user")
-  private String user;
+  @Column(name = "userid")
+  private String userid;
 
   @Column(name = "status")
   private String status;

--- a/src/main/java/yanagishima/model/db/StarredSchema.java
+++ b/src/main/java/yanagishima/model/db/StarredSchema.java
@@ -33,6 +33,6 @@ public class StarredSchema {
   @Column(name = "`schema`")
   private String schema;
 
-  @Column(name = "user")
-  private String user;
+  @Column(name = "userid")
+  private String userid;
 }

--- a/src/main/java/yanagishima/model/trino/TrinoQueryResult.java
+++ b/src/main/java/yanagishima/model/trino/TrinoQueryResult.java
@@ -1,0 +1,19 @@
+package yanagishima.model.trino;
+
+import io.airlift.units.DataSize;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class TrinoQueryResult {
+  private String updateType;
+  private List<String> columns;
+  private List<List<String>> records;
+  private String warningMessage;
+  private String queryId;
+  private int lineNumber;
+  private DataSize rawDataSize;
+}

--- a/src/main/java/yanagishima/repository/BookmarkRepository.java
+++ b/src/main/java/yanagishima/repository/BookmarkRepository.java
@@ -9,9 +9,9 @@ import yanagishima.model.db.Bookmark;
 
 @Repository
 public interface BookmarkRepository extends CrudRepository<Bookmark, Long> {
-  List<Bookmark> findAllByEngineAndUser(String engine, String user);
+  List<Bookmark> findAllByEngineAndUserid(String engine, String userid);
 
-  List<Bookmark> findAllByDatasourceAndEngineAndUser(String datasource, String engine, String user);
+  List<Bookmark> findAllByDatasourceAndEngineAndUserid(String datasource, String engine, String userid);
 
   List<Bookmark> findAllByDatasourceAndBookmarkIdIn(String datasource, List<Integer> bookmarkIds);
 

--- a/src/main/java/yanagishima/repository/PublishRepository.java
+++ b/src/main/java/yanagishima/repository/PublishRepository.java
@@ -15,6 +15,6 @@ public interface PublishRepository extends CrudRepository<Publish, String> {
 
   Optional<Publish> findByPublishId(String publishId);
 
-  List<Publish> findAllByDatasourceAndEngineAndUserOrderByQueryIdDesc(String datasource, String engine,
-                                                                      String user, Pageable pageable);
+  List<Publish> findAllByDatasourceAndEngineAndUseridOrderByQueryIdDesc(String datasource, String engine,
+                                                                        String userid, Pageable pageable);
 }

--- a/src/main/java/yanagishima/repository/QueryRepository.java
+++ b/src/main/java/yanagishima/repository/QueryRepository.java
@@ -12,16 +12,16 @@ import yanagishima.model.db.QueryId;
 
 @Repository
 public interface QueryRepository extends CrudRepository<Query, QueryId> {
-  List<Query> findAllByDatasourceAndEngineAndUserAndQueryStringContainsOrderByQueryIdDesc(
+  List<Query> findAllByDatasourceAndEngineAndUseridAndQueryStringContainsOrderByQueryIdDesc(
       String datasource, String engine, String user, String query, Pageable pageable);
 
   List<Query> findAllByDatasourceAndEngineAndQueryIdIn(String datasource, String engine, List<String> queryIds);
 
-  long countAllByDatasourceAndEngineAndUser(String datasource, String engine, String user);
+  long countAllByDatasourceAndEngineAndUserid(String datasource, String engine, String user);
 
   List<Query> findAllByDatasourceAndQueryIdIn(String datasource, List<String> queryIds);
 
-  Optional<Query> findByQueryIdAndDatasourceAndUser(String queryId, String datasource, String user);
+  Optional<Query> findByQueryIdAndDatasourceAndUserid(String queryId, String datasource, String user);
 
   Optional<Query> findByQueryIdAndDatasourceAndEngine(String queryId, String datasource, String engine);
 

--- a/src/main/java/yanagishima/repository/StarredSchemaRepository.java
+++ b/src/main/java/yanagishima/repository/StarredSchemaRepository.java
@@ -9,8 +9,8 @@ import yanagishima.model.db.StarredSchema;
 
 @Repository
 public interface StarredSchemaRepository extends CrudRepository<StarredSchema, Integer> {
-  List<StarredSchema> findAllByDatasourceAndEngineAndCatalogAndUser(
-      String datasource, String engine, String catalog, String user);
+  List<StarredSchema> findAllByDatasourceAndEngineAndCatalogAndUserid(
+      String datasource, String engine, String catalog, String userid);
 
   void deleteByStarredSchemaId(int starredSchemaId);
 }

--- a/src/main/java/yanagishima/service/BookmarkService.java
+++ b/src/main/java/yanagishima/service/BookmarkService.java
@@ -18,9 +18,9 @@ public class BookmarkService {
 
   public List<Bookmark> getAll(boolean showAll, String datasource, String engine, User user) {
     if (showAll) {
-      return bookmarkRepository.findAllByEngineAndUser(engine, user.getId());
+      return bookmarkRepository.findAllByEngineAndUserid(engine, user.getId());
     }
-    return bookmarkRepository.findAllByDatasourceAndEngineAndUser(datasource, engine, user.getId());
+    return bookmarkRepository.findAllByDatasourceAndEngineAndUserid(datasource, engine, user.getId());
   }
 
   public List<Bookmark> getAll(String datasource, List<Integer> bookmarkIds) {
@@ -34,7 +34,7 @@ public class BookmarkService {
     bookmark.setQuery(query);
     bookmark.setTitle(title);
     bookmark.setEngine(engine);
-    bookmark.setUser(user.getId());
+    bookmark.setUserid(user.getId());
     bookmark.setSnippet(snippet);
 
     return bookmarkRepository.save(bookmark);

--- a/src/main/java/yanagishima/service/CommentService.java
+++ b/src/main/java/yanagishima/service/CommentService.java
@@ -33,7 +33,7 @@ public class CommentService {
     comment.setDatasource(datasource);
     comment.setEngine(engine);
     comment.setQueryid(queryId);
-    comment.setUser(user.getId());
+    comment.setUserid(user.getId());
     comment.setContent(content);
     comment.setLikeCount(0);
     comment.setUpdateTimeString(updateTimeString);
@@ -41,7 +41,7 @@ public class CommentService {
   }
 
   public void update(Comment comment, User user, String content, String updateTimeString) {
-    comment.setUser(user.getId());
+    comment.setUserid(user.getId());
     comment.setContent(content);
     comment.setUpdateTimeString(updateTimeString);
     commentRepository.save(comment);

--- a/src/main/java/yanagishima/service/HiveService.java
+++ b/src/main/java/yanagishima/service/HiveService.java
@@ -241,7 +241,7 @@ public class HiveService {
             statementPool.remove(datasource, queryId);
           }
 
-          queryResult.setRawDataSize(DataSize.ofBytes(Files.size(dst)).succinct());
+          queryResult.setRawDataSize(new DataSize(Files.size(dst), DataSize.Unit.BYTE).convertToMostSuccinctDataSize());
         } catch (IOException e) {
           throw new RuntimeException(e);
         }

--- a/src/main/java/yanagishima/service/PublishService.java
+++ b/src/main/java/yanagishima/service/PublishService.java
@@ -27,7 +27,7 @@ public class PublishService {
   }
 
   public List<Publish> getAll(String datasource, String engine, User user, int limit) {
-    return publishRepository.findAllByDatasourceAndEngineAndUserOrderByQueryIdDesc(datasource, engine,
+    return publishRepository.findAllByDatasourceAndEngineAndUseridOrderByQueryIdDesc(datasource, engine,
             user.getId(), PageRequest.of(0, limit));
   }
 
@@ -42,7 +42,7 @@ public class PublishService {
     publish.setDatasource(datasource);
     publish.setEngine(engine);
     publish.setQueryId(queryId);
-    publish.setUser(user);
+    publish.setUserid(user);
     return publishRepository.save(publish);
   }
 

--- a/src/main/java/yanagishima/service/QueryService.java
+++ b/src/main/java/yanagishima/service/QueryService.java
@@ -33,7 +33,7 @@ public class QueryService {
   private final QueryRepository queryRepository;
 
   public List<Query> getAll(String datasource, String engine, String user, String query, int limit) {
-    return queryRepository.findAllByDatasourceAndEngineAndUserAndQueryStringContainsOrderByQueryIdDesc(
+    return queryRepository.findAllByDatasourceAndEngineAndUseridAndQueryStringContainsOrderByQueryIdDesc(
         datasource, engine, user, query, PageRequest.of(0, limit));
   }
 
@@ -46,7 +46,7 @@ public class QueryService {
   }
 
   public Optional<Query> get(String queryId, String datasource, User user) {
-    return queryRepository.findByQueryIdAndDatasourceAndUser(queryId, datasource, user.getId());
+    return queryRepository.findByQueryIdAndDatasourceAndUserid(queryId, datasource, user.getId());
   }
 
   public Optional<Query> getByEngine(String queryId, String datasource, String engine) {
@@ -58,7 +58,7 @@ public class QueryService {
   }
 
   public long count(String datasource, String engine, String user) {
-    return queryRepository.countAllByDatasourceAndEngineAndUser(datasource, engine, user);
+    return queryRepository.countAllByDatasourceAndEngineAndUserid(datasource, engine, user);
   }
 
   public Query insert(String datasource, String engine, String queryId, String fetchResultTimeString,
@@ -71,7 +71,7 @@ public class QueryService {
     query.setQueryId(queryId);
     query.setFetchResultTimeString(fetchResultTimeString);
     query.setQueryString(queryString);
-    query.setUser(user);
+    query.setUserid(user);
     query.setStatus(status);
     query.setElapsedTimeMillis(elapsedTimeMillis);
     query.setResultFileSize(resultFileSize);
@@ -111,7 +111,7 @@ public class QueryService {
       query.setQueryId(queryId);
       query.setFetchResultTimeString(fetchResultTimeString);
       query.setQueryString(queryString);
-      query.setUser(user);
+      query.setUserid(user);
       query.setStatus(Status.FAILED.name());
       query.setElapsedTimeMillis((int) elapsedTimeMillis);
       query.setResultFileSize(resultFileSize);
@@ -138,7 +138,7 @@ public class QueryService {
       query.setQueryId(queryId);
       query.setFetchResultTimeString(fetchResultTimeString);
       query.setQueryString(queryString);
-      query.setUser(user);
+      query.setUserid(user);
       query.setStatus(Status.SUCCEED.name());
       query.setElapsedTimeMillis((int) elapsedTimeMillis);
       query.setResultFileSize(resultFileSize);

--- a/src/main/java/yanagishima/service/StarredSchemaService.java
+++ b/src/main/java/yanagishima/service/StarredSchemaService.java
@@ -17,7 +17,7 @@ public class StarredSchemaService {
   private final StarredSchemaRepository starredSchemaRepository;
 
   public List<StarredSchema> getAll(String datasource, String engine, String catalog, User user) {
-    return starredSchemaRepository.findAllByDatasourceAndEngineAndCatalogAndUser(datasource, engine, catalog,
+    return starredSchemaRepository.findAllByDatasourceAndEngineAndCatalogAndUserid(datasource, engine, catalog,
                                                                                  user.getId());
   }
 
@@ -27,7 +27,7 @@ public class StarredSchemaService {
     starredSchema.setEngine(engine);
     starredSchema.setCatalog(catalog);
     starredSchema.setSchema(schema);
-    starredSchema.setUser(user.getId());
+    starredSchema.setUserid(user.getId());
     return starredSchemaRepository.save(starredSchema);
   }
 

--- a/src/main/java/yanagishima/util/HistoryUtil.java
+++ b/src/main/java/yanagishima/util/HistoryUtil.java
@@ -34,7 +34,7 @@ public final class HistoryUtil {
     responseBody.put("lineNumber", query.getLinenumber());
     responseBody.put("elapsedTimeMillis", query.getElapsedTimeMillis());
     responseBody.put("rawDataSize", toSuccinctDataSize(query.getResultFileSize()));
-    responseBody.put("user", query.getUser());
+    responseBody.put("userid", query.getUserid());
 
     Map<String, String> map = new HashMap<>();
     for (SessionProperty sessionProperty : sessionPropertyList) {

--- a/src/main/java/yanagishima/util/QueryEngine.java
+++ b/src/main/java/yanagishima/util/QueryEngine.java
@@ -3,5 +3,6 @@ package yanagishima.util;
 public enum QueryEngine {
   hive,
   spark,
-  presto
+  presto,
+  trino
 }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -6,14 +6,49 @@ server:
 spring:
   application:
     name: yanagishima
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+  web:
+    resources:
+      static-locations: file:web
+## Choose one of the following databases
+## MySQL
   datasource:
-    driver-class-name: com.mysql.jdbc.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
-    password: test
-    url: jdbc:mysql://localhost:13306/test?allowPublicKeyRetrieval=true&useSSL=false
-    initialization-mode: always
-  resources:
-    static-locations: file:web
+    password: password
+    url: jdbc:mysql://localhost:3306/yanagishima?useUnicode=yes&characterEncoding=UTF-8&useSSL=false&allowPublicKeyRetrieval=true
+  sql:
+    init:
+      mode: always
+      platform: mysql
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+### PostgreSQL
+#  datasource:
+#    driver-class-name: org.postgresql.Driver
+#    username: postgres
+#    password: password
+#    url: jdbc:postgresql://localhost:5432/postgres?currentSchema=yanagishima
+#  jpa:
+#    database-platform: org.hibernate.dialect.PostgreSQLDialect
+#  sql:
+#    init:
+#      mode: always
+#      platform: postgres
+### SQLite
+#  datasource:
+#    driver-class-name: org.sqlite.JDBC
+#    url: jdbc:sqlite:yanagishima.db
+#  jpa:
+#    database-platform: org.sqlite.hibernate.dialect.SQLiteDialect
+#  sql:
+#    init:
+#      mode: always
+#      platform: sqlite
+
+
 
 # Metrics
 management:
@@ -34,7 +69,7 @@ management:
     web.exposure.include: '*'
 
 # Datasources
-sql.query.engines: presto,hive,spark
+sql.query.engines: trino
 check.datasource: false
 select.limit: 500
 audit.http.header.name: some.auth.header
@@ -42,7 +77,7 @@ use.audit.http.header.name: false
 to.values.query.limit: 500
 cors.enabled: true
 
-# Trino
+# Presto
 presto.datasources: docker-presto
 presto.query.max-run-time-seconds: 1800
 presto.max-result-file-byte-size: 1073741824
@@ -51,6 +86,16 @@ presto.coordinator.server.docker-presto: http://localhost:18080
 presto.redirect.server.docker-presto: http://localhost:18080/ui
 catalog.docker-presto: tpch
 schema.docker-presto: sf1
+
+# Trino
+trino.datasources: docker-trino
+trino.query.max-run-time-seconds: 1800
+trino.max-result-file-byte-size: 1073741824
+auth.docker-trino: false
+trino.coordinator.server.docker-trino: http://localhost:18081
+trino.redirect.server.docker-trino: http://localhost:18081/ui
+catalog.docker-trino: tpch
+schema.docker-trino: sf1
 
 # Hive
 hive.datasources: docker-hive

--- a/src/main/resources/schema-mysql.sql
+++ b/src/main/resources/schema-mysql.sql
@@ -1,0 +1,62 @@
+CREATE TABLE IF NOT EXISTS query (
+datasource varchar(256),
+engine varchar(256),
+query_id varchar(256),
+fetch_result_time_string varchar(256),
+query_string mediumtext,
+userid varchar(256),
+status varchar(256),
+elapsed_time_millis integer,
+result_file_size bigint,
+linenumber integer,
+primary key(datasource, engine, query_id))
+;
+
+CREATE TABLE IF NOT EXISTS publish (
+publish_id varchar(256),
+datasource varchar(256),
+engine varchar(256),
+query_id varchar(256),
+userid varchar(256),
+viewers text,
+primary key(publish_id))
+;
+
+CREATE TABLE IF NOT EXISTS bookmark (
+bookmark_id integer primary key auto_increment,
+datasource varchar(256),
+engine varchar(256),
+query text,
+title varchar(256),
+userid varchar(256),
+snippet varchar(256))
+;
+
+CREATE TABLE IF NOT EXISTS comment (
+datasource varchar(256),
+engine varchar(256),
+query_id varchar(256),
+content text,
+update_time_string varchar(256),
+userid varchar(256),
+like_count integer,
+primary key(datasource, engine, query_id))
+;
+
+CREATE TABLE IF NOT EXISTS starred_schema (
+starred_schema_id integer primary key auto_increment,
+datasource varchar(256) not null,
+engine varchar(256) not null,
+catalog varchar(256) not null,
+`schema` varchar(256) not null,
+userid varchar(256))
+;
+
+CREATE TABLE IF NOT EXISTS session_property (
+session_property_id integer primary key auto_increment,
+datasource varchar(256) not null,
+engine varchar(256) not null,
+query_id varchar(256) not null,
+session_key varchar(256) not null,
+session_value varchar(256) not null)
+;

--- a/src/main/resources/schema-postgres.sql
+++ b/src/main/resources/schema-postgres.sql
@@ -1,0 +1,62 @@
+CREATE TABLE IF NOT EXISTS query (
+datasource varchar(256),
+engine varchar(256),
+query_id varchar(256),
+fetch_result_time_string varchar(256),
+query_string text,
+userid varchar(256),
+status varchar(256),
+elapsed_time_millis integer,
+result_file_size bigint,
+linenumber integer,
+primary key(datasource, engine, query_id))
+;
+
+CREATE TABLE IF NOT EXISTS publish (
+publish_id varchar(256),
+datasource varchar(256),
+engine varchar(256),
+query_id varchar(256),
+userid varchar(256),
+viewers text,
+primary key(publish_id))
+;
+
+CREATE TABLE IF NOT EXISTS bookmark (
+bookmark_id serial primary key,
+datasource varchar(256),
+engine varchar(256),
+query text,
+title varchar(256),
+userid varchar(256),
+snippet varchar(256))
+;
+
+CREATE TABLE IF NOT EXISTS comment (
+datasource varchar(256),
+engine varchar(256),
+query_id varchar(256),
+content text,
+update_time_string varchar(256),
+userid varchar(256),
+like_count integer,
+primary key(datasource, engine, query_id))
+;
+
+CREATE TABLE IF NOT EXISTS starred_schema (
+starred_schema_id serial primary key,
+datasource varchar(256) not null,
+engine varchar(256) not null,
+catalog varchar(256) not null,
+schema varchar(256) not null,
+userid varchar(256))
+;
+
+CREATE TABLE IF NOT EXISTS session_property (
+session_property_id serial primary key,
+datasource varchar(256) not null,
+engine varchar(256) not null,
+query_id varchar(256) not null,
+session_key varchar(256) not null,
+session_value varchar(256) not null)
+;

--- a/src/main/resources/schema-sqlite.sql
+++ b/src/main/resources/schema-sqlite.sql
@@ -4,7 +4,7 @@ engine varchar(256),
 query_id varchar(256),
 fetch_result_time_string varchar(256),
 query_string mediumtext,
-user varchar(256),
+userid varchar(256),
 status varchar(256),
 elapsed_time_millis integer,
 result_file_size bigint,
@@ -17,18 +17,18 @@ publish_id varchar(256),
 datasource varchar(256),
 engine varchar(256),
 query_id varchar(256),
-user varchar(256),
+userid varchar(256),
 viewers text,
 primary key(publish_id))
 ;
 
 CREATE TABLE IF NOT EXISTS bookmark (
-bookmark_id integer primary key auto_increment,
+bookmark_id integer primary key autoincrement,
 datasource varchar(256),
 engine varchar(256),
 query text,
 title varchar(256),
-user varchar(256),
+userid varchar(256),
 snippet varchar(256))
 ;
 
@@ -38,22 +38,22 @@ engine varchar(256),
 query_id varchar(256),
 content text,
 update_time_string varchar(256),
-user varchar(256),
+userid varchar(256),
 like_count integer,
 primary key(datasource, engine, query_id))
 ;
 
 CREATE TABLE IF NOT EXISTS starred_schema (
-starred_schema_id integer primary key auto_increment,
+starred_schema_id integer primary key autoincrement,
 datasource varchar(256) not null,
 engine varchar(256) not null,
 catalog varchar(256) not null,
 `schema` varchar(256) not null,
-user varchar(256))
+userid varchar(256))
 ;
 
 CREATE TABLE IF NOT EXISTS session_property (
-session_property_id integer primary key auto_increment,
+session_property_id integer primary key autoincrement,
 datasource varchar(256) not null,
 engine varchar(256) not null,
 query_id varchar(256) not null,

--- a/src/test/java/yanagishima/controller/ShareControllerTest.java
+++ b/src/test/java/yanagishima/controller/ShareControllerTest.java
@@ -43,7 +43,7 @@ class ShareControllerTest {
     Publish publish = new Publish();
     publish.setPublishId(publishId);
     publish.setQueryId(getQueryId());
-    publish.setUser("Alice");
+    publish.setUserid("Alice");
 
     try (MockedStatic<DownloadUtil> util = Mockito.mockStatic(DownloadUtil.class)) {
       util.when(() -> DownloadUtil.downloadCsv(
@@ -69,7 +69,7 @@ class ShareControllerTest {
     Publish publish = new Publish();
     publish.setPublishId(publishId);
     publish.setQueryId(getQueryId());
-    publish.setUser("Alice");
+    publish.setUserid("Alice");
     publish.setViewers("Bob");
 
     try (MockedStatic<DownloadUtil> util = Mockito.mockStatic(DownloadUtil.class)) {
@@ -96,7 +96,7 @@ class ShareControllerTest {
     Publish publish = new Publish();
     publish.setPublishId(publishId);
     publish.setQueryId(getQueryId());
-    publish.setUser("Alice");
+    publish.setUserid("Alice");
 
     when(publishRepository.findByPublishId(anyString()))
         .thenReturn(Optional.of(publish));

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yanagishima",
-  "version": "22.0.0",
+  "version": "23.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web/src/components/TheHeaderLower.vue
+++ b/web/src/components/TheHeaderLower.vue
@@ -4,8 +4,8 @@
       <BaseAce :code="inputQuery" :goto-line="gotoLine" :focus="focus" :min-lines="settings.minline" :max-lines="Infinity"
            :theme="settings.theme" @change-code="setInputQuery" @run-code="runQuery"
            :error-line="errorLine" :error-text="tinyErrorText" :readonly="loading"
-           :complete-words="isPresto ? completeWords : []"
-           @format-code="isPresto ? formatQuery() : () => {}" @validate-code="isPresto ? validateQuery() : () => {}"></BaseAce>
+           :complete-words="(isPresto || isTrino) ? completeWords : []"
+           @format-code="(isPresto || isTrino) ? formatQuery() : () => {}" @validate-code="(isPresto || isTrino) ? validateQuery() : () => {}"></BaseAce>
     </div>
     <fieldset v-if="variables.length" id="variables" class="mb-3">
       <legend>{{variables.length}} variables</legend>
@@ -34,7 +34,7 @@
                     data-toggle="tooltip" data-animation="false" title="Convert Query"
                     :disabled="!inputQuery.length || loading"><i class="fa fa-fw fa-exchange"></i>
             </button>
-            <button v-if="isPresto" type="button" class="btn btn-secondary px-2" @click.prevent="formatQuery"
+            <button v-if="isPresto || isTrino" type="button" class="btn btn-secondary px-2" @click.prevent="formatQuery"
                     data-toggle="tooltip" data-animation="false" title="Format Query"
                     :disabled="!inputQuery.length || loading"><i class="fa fa-fw fa-indent"></i>
             </button>
@@ -58,11 +58,7 @@
                 <button type="button" class="dropdown-item" :disabled="!runnable" @click="explainQuery">Explain (Text)</button>
                 <button type="button" class="dropdown-item" :disabled="!runnable" @click="explainGraphvizQuery">Explain (Graph)</button>
               </template>
-              <template v-else-if="isHive || isSpark">
-                <button type="button" class="dropdown-item" :disabled="!runnable" @click="explainQuery">Explain</button>
-              </template>
-              <template v-else-if="isElasticsearch">
-                <button type="button" class="dropdown-item" :disabled="!runnable" @click="translateQuery">Translate</button>
+              <template v-else-if="isTrino || isHive || isSpark">
                 <button type="button" class="dropdown-item" :disabled="!runnable" @click="explainQuery">Explain</button>
               </template>
             </div>
@@ -109,7 +105,7 @@ export default {
       'isPresto',
       'isHive',
       'isSpark',
-      'isElasticsearch',
+      'isTrino',
       'datasourceIndex',
       'datasourceEngine'
     ]),
@@ -204,9 +200,6 @@ export default {
       } else {
         throw new Error('not supported')
       }
-    },
-    translateQuery () {
-      this.runQuery(this.inputQuery, true)
     },
     addBookmarkItem () {
       this.$store.dispatch('bookmark/addBookmarkItem')

--- a/web/src/components/TheHeaderUpper.vue
+++ b/web/src/components/TheHeaderUpper.vue
@@ -54,7 +54,8 @@
             <small class="dropdown-item-text text-muted ml-2">Version {{version}}</small>
             <div class="dropdown-divider my-1"></div>
             <a href="#help" class="dropdown-item mr-2" data-toggle="modal" data-target="#help">Help</a>
-            <a v-if="isPresto" href="https://prestosql.io/docs/current/" class="dropdown-item" target="_blank" rel="noopener">Presto Doc</a>
+            <a v-if="isPresto" href="https://prestodb.io/docs/current/" class="dropdown-item" target="_blank" rel="noopener">Presto Doc</a>
+            <a v-if="isTrino" href="https://trino.io/docs/current/" class="dropdown-item" target="_blank" rel="noopener">Trino Doc</a>
             <a v-if="isHive" href="https://cwiki.apache.org/confluence/display/Hive/LanguageManual" class="dropdown-item" target="_blank" rel="noopener">Hive Doc</a>
             <a v-if="isSpark" href="https://spark.apache.org/" class="dropdown-item" target="_blank" rel="noopener">Spark Doc</a>
           </div>
@@ -95,6 +96,7 @@ export default {
     }),
     ...mapGetters([
       'isPresto',
+      'isTrino',
       'isHive',
       'isSpark'
     ]),

--- a/web/src/components/modals/ModalHelp.vue
+++ b/web/src/components/modals/ModalHelp.vue
@@ -23,7 +23,7 @@
                 <td><kbd>Ctrl</kbd> + <kbd>T</kbd></td>
                 <td>Move to <strong>Treeview</strong></td>
               </tr>
-              <tr v-if="isPresto">
+              <tr v-if="isPresto || isTrino">
                 <td>Editor</td>
                 <td><kbd>Ctrl</kbd> + <kbd>Space</kbd></td>
                 <td><strong>Auto-complete</strong> Table/Function</td>
@@ -33,12 +33,12 @@
                 <td><kbd>Ctrl</kbd> + <kbd>Enter</kbd></td>
                 <td><strong>Run</strong> Query</td>
               </tr>
-              <tr v-if="isPresto">
+              <tr v-if="isPresto || isTrino">
                 <td>Editor</td>
                 <td><kbd>Shift</kbd> + <kbd>Enter</kbd></td>
                 <td><strong>Validate</strong> Query</td>
               </tr>
-              <tr v-if="isPresto">
+              <tr v-if="isPresto || isTrino">
                 <td>Editor</td>
                 <td><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>F</kbd></td>
                 <td><strong>Format</strong> Query</td>
@@ -117,7 +117,8 @@ export default {
       engine: state => state.hash.engine
     }),
     ...mapGetters([
-      'isPresto'
+      'isPresto',
+      'isTrino'
     ])
   },
   methods: {

--- a/web/src/components/modals/ModalPartition.vue
+++ b/web/src/components/modals/ModalPartition.vue
@@ -5,7 +5,7 @@
         <div class="modal-header">
           <h5 class="modal-title">
             <strong>Partition list</strong> in
-            <template v-if="isPresto">{{catalog}}.</template>{{schema}}.{{table}}
+            <template v-if="isPresto || isTrino">{{catalog}}.</template>{{schema}}.{{table}}
           </h5>
           <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
         </div>
@@ -77,6 +77,7 @@ export default {
     ]),
     ...mapGetters([
       'isPresto',
+      'isTrino',
       'isHive',
       'isSpark',
       'datasourceEngine'
@@ -160,7 +161,7 @@ export default {
       }
 
       let from
-      if (this.isPresto) {
+      if (this.isPresto || this.isTrino) {
         from = [this.catalog, this.schema, `"${this.table}"`]
       } else if (this.isHive) {
         from = [this.schema, `\`${this.table}\``]

--- a/web/src/components/tabs/TabHistory.vue
+++ b/web/src/components/tabs/TabHistory.vue
@@ -91,7 +91,7 @@
               </td>
               <td class="text-center">
                 <a target="_blank" class="btn btn-sm btn-secondary p-1"
-                  :href="buildDetailUrl(isPresto, isHive, isSpark, isElasticsearch, datasource, h[0])"><i class="fa fa-fw fa-info"></i></a>
+                  :href="buildDetailUrl(isPresto, isHive, isSpark, isTrino, datasource, h[0])"><i class="fa fa-fw fa-info"></i></a>
               </td>
             </tr>
           </tbody>
@@ -141,7 +141,7 @@ export default {
       'isPresto',
       'isHive',
       'isSpark',
-      'isElasticsearch',
+      'isTrino',
       'datasourceEngine'
     ]),
     filterModel: {

--- a/web/src/components/tabs/TabQlist.vue
+++ b/web/src/components/tabs/TabQlist.vue
@@ -3,7 +3,7 @@
     <div class="header d-flex justify-content-between align-items-center pt-3">
       <span><strong class="mr-2">{{datasource}}</strong>as of<strong class="ml-2">{{now}}</strong></span>
       <div class="d-flex align-items-center">
-        <div class="form-check form-check-inline" v-if="isPresto">
+        <div class="form-check form-check-inline" v-if="isPresto || isTrino">
           <input class="form-check-input mr-1" type="checkbox" id="fullQueryCheckbox" v-model="isOpenQueryModel">
           <label class="form-check-label" for="fullQueryCheckbox">Full Query</label>
         </div>
@@ -31,7 +31,7 @@
           <span class="mr-2"><strong>{{orderedQlist.length}}</strong> Results</span>
           <span class="mr-2" v-if="orderedFailQlist.length"><strong>{{orderedFailQlist.length}}</strong> Fails</span>
         </div>
-        <template v-if="isPresto">
+        <template v-if="isPresto || isTrino">
           <table v-if="orderedQlist.length" class="table table-sm table-bordered table-fixed table-hover">
             <thead>
             <tr>
@@ -80,7 +80,7 @@
                 class="fa fa-fw fa-times text-danger"></i></a></td>
               <td class="text-center">
                 <a target="_blank" class="btn btn-sm btn-secondary p-1"
-                   :href="buildDetailUrl(isPresto, isHive, isSpark, isElasticsearch, datasource, item.queryId)"><i class="fa fa-fw fa-info"></i></a>
+                   :href="buildDetailUrl(isPresto, isHive, isSpark, isTrino, datasource, item.queryId)"><i class="fa fa-fw fa-info"></i></a>
               </td>
             </tr>
             </tbody>
@@ -130,7 +130,7 @@
               </td>
               <td>{{item.user}}</td>
               <td class="text-center"><a target="_blank" class="btn btn-sm btn-secondary p-1"
-                                         :href="buildDetailUrl(isPresto, isHive, isSpark, isElasticsearch, datasource, item.id)"><i
+                                         :href="buildDetailUrl(isPresto, isHive, isSpark, isTrino, datasource, item.id)"><i
                 class="fa fa-fw fa-info"></i></a></td>
             </tr>
             </tbody>
@@ -175,7 +175,7 @@
               </td>
               <td><a href="#" @click.prevent="filterUser = item.user">{{item.user}}</a></td>
               <td class="text-center"><a target="_blank" class="btn btn-sm btn-secondary p-1"
-                                         :href="buildDetailUrl(isPresto, isHive, isSpark, isElasticsearch, datasource)"><i
+                                         :href="buildDetailUrl(isPresto, isHive, isSpark, isTrino, datasource)"><i
                 class="fa fa-fw fa-info"></i></a></td>
             </tr>
             </tbody>
@@ -224,7 +224,7 @@ export default {
       'isPresto',
       'isHive',
       'isSpark',
-      'isElasticsearch'
+      'isTrino'
     ]),
     isOpenQueryModel: {
       get () {
@@ -248,7 +248,7 @@ export default {
       }
 
       let qlist
-      if (this.isPresto) {
+      if (this.isPresto || this.isTrino) {
         qlist = this.response.filter(q => {
           if ((this.filterSource === '' || this.filterSource === q.session.source) &&
             (this.filterUser === '' || this.filterUser === q.session.user)) {
@@ -307,7 +307,7 @@ export default {
       this.$store.dispatch('qlist/getQlist', {isAutoQlist: false})
     },
     isRunning (state) {
-      if (this.isPresto) {
+      if (this.isPresto || this.isTrino) {
         return !['FINISHED', 'FAILED', 'CANCELED'].includes(state)
       } else if (this.isHive) {
         return !['FINISHED', 'FAILED', 'KILLED'].includes(state)

--- a/web/src/components/tabs/TabResult.vue
+++ b/web/src/components/tabs/TabResult.vue
@@ -84,7 +84,7 @@
               <div class="btn-group">
                 <a href="#" class="btn btn-sm btn-secondary" @click.prevent="killQuery"><i
                   class="fa fa-fw fa-times mr-1 text-danger"></i>Kill</a>
-                <a class="btn btn-sm btn-secondary" :href="buildDetailUrl(isPresto, isHive, isSpark, isElasticsearch, datasource, runningQueryid)"
+                <a class="btn btn-sm btn-secondary" :href="buildDetailUrl(isPresto, isHive, isSpark, isTrino, datasource, runningQueryid)"
                    :target="'_blank'"><i class="fa fa-fw fa-info"></i>Info</a>
               </div>
             </div>
@@ -246,7 +246,7 @@ export default {
       'isPresto',
       'isHive',
       'isSpark',
-      'isElasticsearch',
+      'isTrino',
       'datasourceEngine'
     ]),
     ...mapState('result', [
@@ -258,7 +258,6 @@ export default {
       'loading',
       'response',
       'error',
-      'label',
       'editLabel'
     ]),
     isPrettyModel: {
@@ -376,17 +375,6 @@ export default {
           })
         })
         .catch(() => {})
-    },
-    moveHisotryTab (label) {
-      this.$store.commit('history/setLabel', {data: label})
-      this.$store.commit('setHashItem', {tab: 'history'})
-    },
-    addLabel () {
-      this.$store.dispatch('result/postLabel', {inputLabel: this.inputLabel})
-      this.inputLabel = null
-    },
-    removeLabel () {
-      this.$store.dispatch('result/deleteLabel')
     }
   }
 }

--- a/web/src/mixins/util.js
+++ b/web/src/mixins/util.js
@@ -17,8 +17,8 @@ export default {
     buildDownloadUrl (datasource, queryid, isCsv, includeHeader) {
       return api.buildDownloadUrl(datasource, queryid, isCsv, includeHeader)
     },
-    buildDetailUrl (isPresto, isHive, isSpark, isElasticsearch, datasource, queryid) {
-      return api.buildDetailUrl(isPresto, isHive, isSpark, isElasticsearch, datasource, queryid)
+    buildDetailUrl (isPresto, isHive, isSpark, isTrino, datasource, queryid) {
+      return api.buildDetailUrl(isPresto, isHive, isSpark, isTrino, datasource, queryid)
     },
     buildShareDownloadUrl (publishId, isCsv, includeHeader) {
       return api.buildShareDownloadUrl(publishId, isCsv, includeHeader)

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -124,14 +124,14 @@ export default new Vuex.Store({
     isPresto (state) {
       return state.hash.engine === 'presto'
     },
+    isTrino (state) {
+      return state.hash.engine === 'trino'
+    },
     isHive (state) {
       return state.hash.engine === 'hive'
     },
     isSpark (state) {
       return state.hash.engine === 'spark'
-    },
-    isElasticsearch (state) {
-      return state.hash.engine === 'elasticsearch'
     },
     authInfo (state) {
       return state.auths[state.hash.datasource] ? {

--- a/web/src/store/modules/editor.js
+++ b/web/src/store/modules/editor.js
@@ -64,9 +64,9 @@ const actions = {
     }
   },
   async getCompleteWords ({commit, rootState, rootGetters}) {
-    const {isPresto} = rootGetters
+    const {isPresto, isTrino} = rootGetters
 
-    if (!isPresto) {
+    if (!(isPresto || isTrino)) {
       return false
     }
 

--- a/web/src/store/modules/qlist.js
+++ b/web/src/store/modules/qlist.js
@@ -19,7 +19,7 @@ const getters = {}
 const actions = {
   async getQlist ({commit, rootState, rootGetters}, {isAutoQlist}) {
     const {datasource} = rootState.hash
-    const {isPresto, isHive, isSpark, isElasticsearch, authInfo} = rootGetters
+    const {isPresto, isHive, isSpark, isTrino, authInfo} = rootGetters
 
     isAutoQlist = isAutoQlist || false
 
@@ -33,13 +33,12 @@ const actions = {
       let data
       if (isPresto) {
         data = await api.getQlistPresto(datasource, authInfo)
+      } else if (isTrino) {
+        data = await api.getQlistTrino(datasource)
       } else if (isHive) {
         data = await api.getQlistHive(datasource)
       } else if (isSpark) {
         data = await api.getQlistSpark(datasource)
-      } else if (isElasticsearch) {
-        commit('setLoading', {data: false})
-        return
       } else {
         throw new Error('not supported')
       }
@@ -54,9 +53,9 @@ const actions = {
     commit('setLoading', {data: false})
   },
   async autoQlist ({dispatch, rootState, rootGetters}, {enable}) {
-    const {isPresto} = rootGetters
+    const {isPresto, isTrino} = rootGetters
     const refreshPeriod = 1
-    const period = isPresto ? 1000 : 1000 * 10
+    const period = (isPresto || isTrino) ? 1000 : 1000 * 10
 
     enable = enable || false
 


### PR DESCRIPTION
This pull request aims to introduce a newer Trino client to replace the old one, and proper support for [Presto](https://github.com/prestodb/presto), which has been separated with Trino a long time ago.

## Major changes
* Support Trino 419 or newer
* Support Presto 0.282 or newer

## Accompanying changes
* Upgrade Gradle to 8.0 and update backend dependencies
* Remove calls to the removed APIs (`/label`, `/elasticsearch`) from frontend
* Add PostgreSQL and SQLite as optional backend databases